### PR TITLE
Fix nil pointer dereference error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+v1.5.2
+------
+
+* Fix nil pointer dereference if network does not exist anymore (#42).
+
 v1.5.1
 ------
 * Add better error handling and validation for certain errors related to wrong API tokens

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ kubectl -n kube-system create secret generic hcloud --from-literal=token=<hcloud
 7. Deploy the `hcloud-cloud-controller-manager`:
 
 ```
-kubectl apply -f  https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/v1.5.1.yaml
+kubectl apply -f  https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/v1.5.2.yaml
 
 ```
 

--- a/deploy/v1.5.2-networks.yaml
+++ b/deploy/v1.5.2-networks.yaml
@@ -1,5 +1,4 @@
 # NOTE: this release was tested against kubernetes v1.16.x
-
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -53,14 +52,17 @@ spec:
           effect: NoSchedule
         - key: "node.kubernetes.io/not-ready"
           effect: "NoSchedule"
+      hostNetwork: true
       containers:
-        - image: hetznercloud/hcloud-cloud-controller-manager:v1.5.1
+        - image: hetznercloud/hcloud-cloud-controller-manager:v1.5.2
           name: hcloud-cloud-controller-manager
           command:
             - "/bin/hcloud-cloud-controller-manager"
             - "--cloud-provider=hcloud"
             - "--leader-elect=false"
             - "--allow-untagged-cloud"
+            - "--allocate-node-cidrs=true"
+            - "--cluster-cidr=10.244.0.0/16"
           resources:
             requests:
               cpu: 100m
@@ -75,3 +77,8 @@ spec:
                 secretKeyRef:
                   name: hcloud
                   key: token
+            - name: HCLOUD_NETWORK
+              valueFrom:
+                secretKeyRef:
+                  name: hcloud
+                  key: network

--- a/deploy/v1.5.2.yaml
+++ b/deploy/v1.5.2.yaml
@@ -1,4 +1,5 @@
 # NOTE: this release was tested against kubernetes v1.16.x
+
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -52,17 +53,14 @@ spec:
           effect: NoSchedule
         - key: "node.kubernetes.io/not-ready"
           effect: "NoSchedule"
-      hostNetwork: true
       containers:
-        - image: hetznercloud/hcloud-cloud-controller-manager:v1.5.1
+        - image: hetznercloud/hcloud-cloud-controller-manager:v1.5.2
           name: hcloud-cloud-controller-manager
           command:
             - "/bin/hcloud-cloud-controller-manager"
             - "--cloud-provider=hcloud"
             - "--leader-elect=false"
             - "--allow-untagged-cloud"
-            - "--allocate-node-cidrs=true"
-            - "--cluster-cidr=10.244.0.0/16"
           resources:
             requests:
               cpu: 100m
@@ -77,8 +75,3 @@ spec:
                 secretKeyRef:
                   name: hcloud
                   key: token
-            - name: HCLOUD_NETWORK
-              valueFrom:
-                secretKeyRef:
-                  name: hcloud
-                  key: network

--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -33,7 +33,7 @@ const (
 	hcloudNetworkENVVar  = "HCLOUD_NETWORK"
 	nodeNameENVVar       = "NODE_NAME"
 	providerName         = "hcloud"
-	providerVersion      = "v1.5.1"
+	providerVersion      = "v1.5.2"
 )
 
 type cloud struct {

--- a/hcloud/routes.go
+++ b/hcloud/routes.go
@@ -23,6 +23,9 @@ func newRoutes(client *hcloud.Client, network string) (*routes, error) {
 	if err != nil {
 		return nil, err
 	}
+	if networkObj == nil {
+		return nil, fmt.Errorf("network not found: %s", network)
+	}
 
 	return &routes{client, networkObj, make(map[string]string), make(map[string]net.IP)}, nil
 }
@@ -31,6 +34,9 @@ func (r *routes) reloadNetwork(ctx context.Context) error {
 	networkObj, _, err := r.client.Network.GetByID(ctx, r.network.ID)
 	if err != nil {
 		return err
+	}
+	if networkObj == nil {
+		return fmt.Errorf("network not found: %s", r.network.Name)
 	}
 	r.network = networkObj
 	return nil


### PR DESCRIPTION
hcloud-go returns nil but no error if the network was not found by name. This
in turn leads to a panic once it is tried to reload the network by ID.