### PR TITLE
Fix nil pointer dereference when a network was not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+master
+------
+
+* Fix: nil pointer dereference when Network was not found
+* Update hcloud-go to 1.18.1
+
 v1.6.1
 ------
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/golang/groupcache v0.0.0-20171101203131-84a468cf14b4 // indirect
-	github.com/hetznercloud/hcloud-go v1.18.0
+	github.com/hetznercloud/hcloud-go v1.18.1
 	github.com/stretchr/testify v1.6.1
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
 	gopkg.in/square/go-jose.v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -298,8 +298,8 @@ github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible/go.mod h1:bB9ly3RchcQqsQ9CpyaQwvva7RS5ytVoSoholZQON6o=
 github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6/go.mod h1:xGMAM8JLi7UkZt1i4FQeQy0R2T8GLUwQhOP5M1gBhy4=
-github.com/hetznercloud/hcloud-go v1.18.0 h1:gNmwDQ/Jt7bc7dqb0E1x5hJ52yyYJN8q8OHh/Oq3mMo=
-github.com/hetznercloud/hcloud-go v1.18.0/go.mod h1:EhElojlVU1biA5JgBaV8rRU1vE5+iYke402kXC9pooE=
+github.com/hetznercloud/hcloud-go v1.18.1 h1:iI0/OrGcg2Cl2f4K7UFInWezcn5YuS+UVdfOI+mIMV4=
+github.com/hetznercloud/hcloud-go v1.18.1/go.mod h1:EhElojlVU1biA5JgBaV8rRU1vE5+iYke402kXC9pooE=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=

--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -80,6 +80,9 @@ func newCloud(config io.Reader) (cloudprovider.Interface, error) {
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", op, err)
 		}
+		if n == nil {
+			return nil, fmt.Errorf("%s: Network %s not found", op, v)
+		}
 		networkID = n.ID
 	}
 	if networkID == 0 {


### PR DESCRIPTION
Fix nil pointer dereference when a network was not found, this fixes #60 


It also updates the hcloud-go to the latest version