### PR TITLE
Fix secret creation in deploy with networks guide.

### DIFF
--- a/docs/deploy_with_networks.md
+++ b/docs/deploy_with_networks.md
@@ -8,9 +8,8 @@ We assume, that you have knowledge about Kubernetes and the Hetzner Cloud.
  1. Create a new Network via `hcloud-cli` (`hcloud network create --name my-network --ip-range=10.0.0.0/8`)or the [Hetzner Cloud Console](https://console.hetzner.cloud)
  2. Download the latest deployment file with networks support from [Github](https://github.com/hetznercloud/hcloud-cloud-controller-manager/tree/master/deploy) to your local machine
  3. Change the `--cluster-cidr=` flag in the deployment file to fit your pod range. Default is `10.244.0.0/16`.
- 4. Create a new secret containing a Hetzner Cloud API Token `kubectl -n kube-system create secret generic hcloud --from-literal=token=<hcloud API token>`
- 5. Create a new secret containing the name or the ID of the Network you want to use `kubectl -n kube-system create secret generic hcloud --from-literal=network=<hcloud Network_ID_or_Name>`
- 6. Deploy the deployment file `kubectl -n kube-system apply -f path/to/your/deployment.yaml`
- 7. (Recommended) Deploy a CNI (like Cilium `kubectl create -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/<kubernetes-version>/cilium.yaml` - please replace `<kubernetes-version>` with your version like `1.15`)
+ 4. Create a new secret containing a Hetzner Cloud API Token and the name or the ID of the Network you want to use `kubectl -n kube-system create secret generic hcloud --from-literal=token=<hcloud API token> --from-literal=network=<hcloud Network_ID_or_Name>`
+ 5. Deploy the deployment file `kubectl -n kube-system apply -f path/to/your/deployment.yaml`
+ 6. (Recommended) Deploy a CNI (like Cilium `kubectl create -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/<kubernetes-version>/cilium.yaml` - please replace `<kubernetes-version>` with your version like `1.15`)
  
 After this, you should be able to see the correct routes in the [Hetzner Cloud Console](https://console.hetzner.cloud) or via `hcloud-cli` (`hcloud networks describe <hcloud Network_ID_or_Name>`).


### PR DESCRIPTION
The previous two steps could not work since they tried to create the same secret twice. The secret must be created in one step.