### PR TITLE
Add option to keep server after e2e test failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ If you want to use the Hetzner Cloud `Networks` Feature, head over to the [Deplo
 
 ## E2E Tests
 
-The Hetzner Cloud cloud controller manager was tested against all supported Kubernetes versions. You can run the tests with the following commands. Keep in mind, that these tests run on real cloud servers and will create Load Balancers that will be billed. 
+The Hetzner Cloud cloud controller manager was tested against all supported Kubernetes versions. You can run the tests with the following commands. Keep in mind, that these tests run on real cloud servers and will create Load Balancers that will be billed.
 
-**Test Server Setup:** 
+**Test Server Setup:**
 1x CPX21 (Ubuntu 18.04)
 
 **Requirements: Docker and Go 1.15**
@@ -128,6 +128,7 @@ export USE_SSH_KEYS=key1,key2 # Name or IDs of your SSH Keys within the Hetzner 
 export USE_NETWORKS=yes # if `yes` this identidicates that the tests should provision the server with cilium as CNI and also enable the Network related tests
 ## Optional configuration env vars:
 export TEST_DEBUG_MODE=yes # With this env you can toggle the output of the provision and test commands. With `yes` it will log the whole output to stdout
+export KEEP_SERVER_ON_FAILURE=yes # Keep the test server after a test failure.
 ```
 
 2. Run the tests

--- a/e2etests/e2e_test.go
+++ b/e2etests/e2e_test.go
@@ -23,7 +23,7 @@ func TestMain(m *testing.M) {
 
 	rc := m.Run()
 
-	if err := testCluster.Stop(); err != nil {
+	if err := testCluster.Stop(rc > 0); err != nil {
 		fmt.Printf("%v\n", err)
 		os.Exit(1)
 	}

--- a/e2etests/setup.go
+++ b/e2etests/setup.go
@@ -27,6 +27,7 @@ type hcloudK8sSetup struct {
 	HcloudToken    string
 	K8sVersion     string
 	TestIdentifier string
+	KeepOnFailure  bool
 	privKey        string
 	server         *hcloud.Server
 	sshKey         *hcloud.SSHKey
@@ -283,8 +284,17 @@ func (s *hcloudK8sSetup) waitForCloudInit() error {
 // TearDown deletes all created resources within the Hetzner Cloud
 // there is no need to "shutdown" the k8s cluster before
 // so we just delete all created resources
-func (s *hcloudK8sSetup) TearDown(ctx context.Context) error {
+func (s *hcloudK8sSetup) TearDown(testFailed bool) error {
 	const op = "hcloudK8sSetup/TearDown"
+
+	if s.KeepOnFailure && testFailed {
+		fmt.Println("Skipping tear-down for further analysis.")
+		fmt.Println("Please clean-up afterwards ;-)")
+		return nil
+	}
+
+	ctx := context.Background()
+
 	_, err := s.Hcloud.Server.Delete(ctx, s.server)
 	if err != nil {
 		return fmt.Errorf("%s Hcloud.Server.Delete: %s", op, err)

--- a/scripts/e2etest-local.sh
+++ b/scripts/e2etest-local.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+
+function test_k8s_version() {
+    if [[ -z "$1" ]]; then
+        echo "Usage: $0 <k8s-version>"
+        return 1
+    fi
+
+    export K8S_VERSION="$1"
+
+    echo "Testing K8S $K8S_VERSION without network support"
+    export USE_NETWORKS="no"
+    if ! go test -count=1 -v -timeout 60m ./e2etests; then
+        return 2
+    fi
+
+    echo
+    echo
+    echo "Testing K8S $K8S_VERSION with network support"
+    export USE_NETWORKS="yes"
+    if ! go test -count=1 -v -timeout 60m ./e2etests; then
+        return 2
+    fi
+}
+
+if [[ -z "$HCLOUD_TOKEN" ]]; then
+    echo "HCLOUD_TOKEN not set! Aborting tests."
+    exit 1
+fi
+
+K8S_VERSIONS=("1.17.12" "1.18.9" "1.19.3")
+for v in "${K8S_VERSIONS[@]}"; do
+    test_k8s_version "$v"
+done


### PR DESCRIPTION
This allows manual analysis of the environment after a test failure.