### PR TITLE
Add load balancer defaults via env

### DIFF
--- a/.github/workflows/bot_stale.yml
+++ b/.github/workflows/bot_stale.yml
@@ -15,5 +15,5 @@ jobs:
           stale-pr-message: 'This PR has been marked as stale because it has not had recent activity. The bot will close the PR if no further action occurs.'
           exempt-pr-label: 'pinned'
           stale-pr-label: 'stale'
-          days-before-stale: 30
+          days-before-stale: 60
           days-before-close: 5

--- a/.github/workflows/goimports.yml
+++ b/.github/workflows/goimports.yml
@@ -1,5 +1,5 @@
 name: Check imports
-on: [push]
+on: [ push, pull_request ]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 ---
 name: Run tests
-on: [push]
+on: [ push, pull_request ]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -1,5 +1,5 @@
 name: Run e2e tests
-on: [push]
+on: [ push ]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: [ 1.17.13, 1.18.10, 1.19.3]
+        k8s: [ 1.17.14, 1.18.12, 1.19.4 ]
         networks: [yes, no]
     name: ${{ matrix.k8s }}- networks - ${{ matrix.networks }}
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ test:unit:
   stage: E2E
   image: docker:git
   variables:
-    K8S_VERSION: 1.17.12
+    K8S_VERSION: 1.18.12
   before_script:
     - apk add --no-cache git make musl-dev go openssh-client
   script:
@@ -53,32 +53,32 @@ test:unit:
 k8s-1.17:
   <<: *testk8se2e
   variables:
-    K8S_VERSION: 1.17.12
+    K8S_VERSION: 1.17.14
 
 k8s-1.17 networks:
   <<: *testk8se2e
   variables:
-    K8S_VERSION: 1.17.12
+    K8S_VERSION: 1.17.14
     USE_NETWORKS: "yes"
 
 k8s-1.18:
   <<: *testk8se2e
   variables:
-    K8S_VERSION: 1.18.9
+    K8S_VERSION: 1.18.12
 
 k8s-1.18 networks:
   <<: *testk8se2e
   variables:
-    K8S_VERSION: 1.18.9
+    K8S_VERSION: 1.18.12
     USE_NETWORKS: "yes"
 
 k8s-1.19:
   <<: *testk8se2e
   variables:
-    K8S_VERSION: 1.19.3
+    K8S_VERSION: 1.19.4
 
 k8s-1.19 networks:
   <<: *testk8se2e
   variables:
-    K8S_VERSION: 1.19.3
+    K8S_VERSION: 1.19.4
     USE_NETWORKS: "yes"

--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ If you want to use the Hetzner Cloud `Networks` Feature, head over to the [Deplo
 
 ## E2E Tests
 
-The Hetzner Cloud cloud controller manager was tested against all supported Kubernetes versions. You can run the tests with the following commands. Keep in mind, that these tests run on real cloud servers and will create Load Balancers that will be billed. 
+The Hetzner Cloud cloud controller manager was tested against all supported Kubernetes versions. You can run the tests with the following commands. Keep in mind, that these tests run on real cloud servers and will create Load Balancers that will be billed.
 
-**Test Server Setup:** 
+**Test Server Setup:**
 1x CPX21 (Ubuntu 18.04)
 
 **Requirements: Docker and Go 1.15**
@@ -128,6 +128,7 @@ export USE_SSH_KEYS=key1,key2 # Name or IDs of your SSH Keys within the Hetzner 
 export USE_NETWORKS=yes # if `yes` this identidicates that the tests should provision the server with cilium as CNI and also enable the Network related tests
 ## Optional configuration env vars:
 export TEST_DEBUG_MODE=yes # With this env you can toggle the output of the provision and test commands. With `yes` it will log the whole output to stdout
+export KEEP_SERVER_ON_FAILURE=yes # Keep the test server after a test failure.
 ```
 
 2. Run the tests

--- a/e2etests/e2e_test.go
+++ b/e2etests/e2e_test.go
@@ -23,7 +23,7 @@ func TestMain(m *testing.M) {
 
 	rc := m.Run()
 
-	if err := testCluster.Stop(); err != nil {
+	if err := testCluster.Stop(rc > 0); err != nil {
 		fmt.Printf("%v\n", err)
 		os.Exit(1)
 	}

--- a/e2etests/setup.go
+++ b/e2etests/setup.go
@@ -27,6 +27,7 @@ type hcloudK8sSetup struct {
 	HcloudToken    string
 	K8sVersion     string
 	TestIdentifier string
+	KeepOnFailure  bool
 	privKey        string
 	server         *hcloud.Server
 	sshKey         *hcloud.SSHKey
@@ -283,8 +284,17 @@ func (s *hcloudK8sSetup) waitForCloudInit() error {
 // TearDown deletes all created resources within the Hetzner Cloud
 // there is no need to "shutdown" the k8s cluster before
 // so we just delete all created resources
-func (s *hcloudK8sSetup) TearDown(ctx context.Context) error {
+func (s *hcloudK8sSetup) TearDown(testFailed bool) error {
 	const op = "hcloudK8sSetup/TearDown"
+
+	if s.KeepOnFailure && testFailed {
+		fmt.Println("Skipping tear-down for further analysis.")
+		fmt.Println("Please clean-up afterwards ;-)")
+		return nil
+	}
+
+	ctx := context.Background()
+
 	_, err := s.Hcloud.Server.Delete(ctx, s.server)
 	if err != nil {
 		return fmt.Errorf("%s Hcloud.Server.Delete: %s", op, err)

--- a/hcloud/testing.go
+++ b/hcloud/testing.go
@@ -73,6 +73,7 @@ type LoadBalancerTestCase struct {
 	Nodes              []*v1.Node
 	LB                 *hcloud.LoadBalancer
 	LBCreateResult     *hcloud.LoadBalancerCreateResult
+	env                map[string]string
 	Mock               func(t *testing.T, tt *LoadBalancerTestCase)
 
 	// Defines the actual test
@@ -90,6 +91,10 @@ type LoadBalancerTestCase struct {
 
 func (tt *LoadBalancerTestCase) run(t *testing.T) {
 	t.Helper()
+
+	for k, v := range tt.env {
+		os.Setenv(k, v)
+	}
 
 	tt.LBOps = &hcops.MockLoadBalancerOps{}
 	tt.LBOps.Test(t)
@@ -121,6 +126,10 @@ func (tt *LoadBalancerTestCase) run(t *testing.T) {
 	tt.LBOps.AssertExpectations(t)
 	tt.LBClient.AssertExpectations(t)
 	tt.ActionClient.AssertExpectations(t)
+
+	for k, _ := range tt.env {
+		os.Unsetenv(k)
+	}
 }
 
 func RunLoadBalancerTests(t *testing.T, tests []LoadBalancerTestCase) {

--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -346,15 +346,10 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 	usePrivateIP, err := annotation.LBUsePrivateIP.BoolFromService(svc)
 	if err != nil {
 		if errors.Is(err, annotation.ErrNotSet) {
-			klog.Info("Not set")
 			if usePrivateIPDefault, ok := os.LookupEnv(hcloudLoadBalancersDefaultUsePrivateIPENVVar); ok {
 				if usePrivateIP, err = strconv.ParseBool(usePrivateIPDefault); err != nil {
-					klog.Info("to bool failed")
 					return changed, fmt.Errorf("%s: %w", op, err)
 				}
-				klog.Info("ok")
-			} else {
-				klog.Info("no default")
 			}
 		} else {
 			return changed, fmt.Errorf("%s: %w", op, err)

--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -344,10 +344,17 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 	)
 
 	usePrivateIP, err := annotation.LBUsePrivateIP.BoolFromService(svc)
-	if err != nil && !errors.Is(err, annotation.ErrNotSet) {
-		if usePrivateIPDefault, ok := os.LookupEnv(hcloudLoadBalancersDefaultUsePrivateIPENVVar); ok {
-			if usePrivateIP, err = strconv.ParseBool(usePrivateIPDefault); err == nil {
-				return changed, fmt.Errorf("%s: %w", op, err)
+	if err != nil {
+		if errors.Is(err, annotation.ErrNotSet) {
+			klog.Info("Not set")
+			if usePrivateIPDefault, ok := os.LookupEnv(hcloudLoadBalancersDefaultUsePrivateIPENVVar); ok {
+				if usePrivateIP, err = strconv.ParseBool(usePrivateIPDefault); err != nil {
+					klog.Info("to bool failed")
+					return changed, fmt.Errorf("%s: %w", op, err)
+				}
+				klog.Info("ok")
+			} else {
+				klog.Info("no default")
 			}
 		} else {
 			return changed, fmt.Errorf("%s: %w", op, err)

--- a/scripts/e2etest-local.sh
+++ b/scripts/e2etest-local.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+
+function test_k8s_version() {
+    if [[ -z "$1" ]]; then
+        echo "Usage: $0 <k8s-version>"
+        return 1
+    fi
+
+    export K8S_VERSION="$1"
+
+    echo "Testing K8S $K8S_VERSION without network support"
+    export USE_NETWORKS="no"
+    if ! go test -count=1 -v -timeout 60m ./e2etests; then
+        return 2
+    fi
+
+    echo
+    echo
+    echo "Testing K8S $K8S_VERSION with network support"
+    export USE_NETWORKS="yes"
+    if ! go test -count=1 -v -timeout 60m ./e2etests; then
+        return 2
+    fi
+}
+
+if [[ -z "$HCLOUD_TOKEN" ]]; then
+    echo "HCLOUD_TOKEN not set! Aborting tests."
+    exit 1
+fi
+
+K8S_VERSIONS=("1.17.12" "1.18.9" "1.19.3")
+for v in "${K8S_VERSIONS[@]}"; do
+    test_k8s_version "$v"
+done

--- a/scripts/e2etest-local.sh
+++ b/scripts/e2etest-local.sh
@@ -30,7 +30,7 @@ if [[ -z "$HCLOUD_TOKEN" ]]; then
     exit 1
 fi
 
-K8S_VERSIONS=("1.17.12" "1.18.9" "1.19.3")
+K8S_VERSIONS=("1.17.13" "1.18.12" "1.19.4")
 for v in "${K8S_VERSIONS[@]}"; do
     test_k8s_version "$v"
 done


### PR DESCRIPTION
Add env for: 
- HCLOUD_LOAD_BALANCERS_DEFAULT_LOCATION
- HCLOUD_LOAD_BALANCERS_DEFAULT_NETWORK_ZONE
- HCLOUD_LOAD_BALANCERS_DEFAULT_USE_PRIVATE_IP
- HCLOUD_LOAD_BALANCERS_DEFAULT_DISABLE_PRIVATE_INGRESS

HCLOUD_LOAD_BALANCERS_DEFAULT_LOCATION and HCLOUD_LOAD_BALANCERS_DEFAULT_NETWORK_ZONE help with the error of "neither load-balancer.hetzner.cloud/location or load-balancer.hetzner.cloud/network-zone are set".
This removes the need to set these annotations over and over again if the cluster is only in a single location.