### PR TITLE
Update of disable-public-network annotation

### DIFF
--- a/internal/mocks/loadbalancer.go
+++ b/internal/mocks/loadbalancer.go
@@ -95,3 +95,17 @@ func (m *LoadBalancerClient) DetachFromNetwork(
 	args := m.Called(ctx, lb, opts)
 	return getActionPtr(args, 0), getResponsePtr(args, 1), args.Error(2)
 }
+
+func (m *LoadBalancerClient) EnablePublicInterface(
+	ctx context.Context, lb *hcloud.LoadBalancer,
+) (*hcloud.Action, *hcloud.Response, error) {
+	args := m.Called(ctx, lb)
+	return getActionPtr(args, 0), getResponsePtr(args, 1), args.Error(2)
+}
+
+func (m *LoadBalancerClient) DisablePublicInterface(
+	ctx context.Context, lb *hcloud.LoadBalancer,
+) (*hcloud.Action, *hcloud.Response, error) {
+	args := m.Called(ctx, lb)
+	return getActionPtr(args, 0), getResponsePtr(args, 1), args.Error(2)
+}


### PR DESCRIPTION
Up until now the disable-public-network annotation only affected newly
created Load Balancers. This commit implements modifying existing Load
Balancers upon changing the annotation.

Closes #127