### PR TITLE
Identify Load Balancers by K8S service UID

### DIFF
--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -104,7 +104,7 @@ func newCloud(config io.Reader) (cloudprovider.Interface, error) {
 		NetworkID:     networkID,
 	}
 
-	loadBalancers := newLoadBalancers(lbOps, &client.LoadBalancer, &client.Action)
+	loadBalancers := newLoadBalancers(lbOps, &client.Action)
 	if os.Getenv(hcloudLoadBalancersEnabledENVVar) == "false" {
 		loadBalancers = nil
 	}

--- a/hcloud/load_balancers.go
+++ b/hcloud/load_balancers.go
@@ -18,7 +18,9 @@ import (
 type LoadBalancerOps interface {
 	GetByName(ctx context.Context, name string) (*hcloud.LoadBalancer, error)
 	GetByID(ctx context.Context, id int) (*hcloud.LoadBalancer, error)
+	GetByK8SServiceUID(ctx context.Context, svc *v1.Service) (*hcloud.LoadBalancer, error)
 	Create(ctx context.Context, lbName string, service *v1.Service) (*hcloud.LoadBalancer, error)
+	Delete(ctx context.Context, lb *hcloud.LoadBalancer) error
 	ReconcileHCLB(ctx context.Context, lb *hcloud.LoadBalancer, svc *v1.Service) (bool, error)
 	ReconcileHCLBTargets(ctx context.Context, lb *hcloud.LoadBalancer, svc *v1.Service, nodes []*v1.Node) (bool, error)
 	ReconcileHCLBServices(ctx context.Context, lb *hcloud.LoadBalancer, svc *v1.Service) (bool, error)
@@ -26,23 +28,24 @@ type LoadBalancerOps interface {
 
 type loadBalancers struct {
 	lbOps LoadBalancerOps
-	lbs   hcops.HCloudLoadBalancerClient // Deprecated: should only be referenced by hcops types
-	ac    hcops.HCloudActionClient       // Deprecated: should only be referenced by hcops types
+	ac    hcops.HCloudActionClient // Deprecated: should only be referenced by hcops types
 }
 
-func newLoadBalancers(
-	lbOps LoadBalancerOps, lbs hcops.HCloudLoadBalancerClient, ac hcops.HCloudActionClient,
-) *loadBalancers {
-	return &loadBalancers{lbOps: lbOps, lbs: lbs, ac: ac}
+func newLoadBalancers(lbOps LoadBalancerOps, ac hcops.HCloudActionClient) *loadBalancers {
+	return &loadBalancers{lbOps: lbOps, ac: ac}
 }
 
-func (l *loadBalancers) GetLoadBalancer(ctx context.Context, clusterName string, service *v1.Service) (status *v1.LoadBalancerStatus, exists bool, err error) {
-	loadBalancer, err := l.lbOps.GetByName(ctx, l.GetLoadBalancerName(ctx, clusterName, service))
+func (l *loadBalancers) GetLoadBalancer(
+	ctx context.Context, _ string, service *v1.Service,
+) (status *v1.LoadBalancerStatus, exists bool, err error) {
+	const op = "hcloud/loadBalancers.GetLoadBalancer"
+
+	lb, err := l.lbOps.GetByK8SServiceUID(ctx, service)
 	if err != nil {
 		if errors.Is(err, hcops.ErrNotFound) {
 			return nil, false, nil
 		}
-		return nil, false, err
+		return nil, false, fmt.Errorf("%s: %v", op, err)
 	}
 
 	if v, ok := annotation.LBHostname.StringFromService(service); ok {
@@ -53,7 +56,7 @@ func (l *loadBalancers) GetLoadBalancer(ctx context.Context, clusterName string,
 
 	return &v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{
 		{
-			IP: loadBalancer.PublicNet.IPv4.IP.String(),
+			IP: lb.PublicNet.IPv4.IP.String(),
 		},
 		// {
 		// 	IP: loadBalancer.PublicNet.IPv6.IP.String(),
@@ -69,65 +72,83 @@ func (l *loadBalancers) GetLoadBalancerName(ctx context.Context, clusterName str
 }
 
 func (l *loadBalancers) EnsureLoadBalancer(
-	ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node,
+	ctx context.Context, clusterName string, svc *v1.Service, nodes []*v1.Node,
 ) (*v1.LoadBalancerStatus, error) {
 	const op = "hcloud/loadBalancers.EnsureLoadBalancer"
-	var reload bool
+	var (
+		reload bool
+		lb     *hcloud.LoadBalancer
+		err    error
+	)
 
 	nodeNames := make([]string, len(nodes))
 	for i, n := range nodes {
 		nodeNames[i] = n.Name
 	}
-	klog.InfoS("ensure Load Balancer", "op", op, "service", service.Name, "nodes", nodeNames)
+	klog.InfoS("ensure Load Balancer", "op", op, "service", svc.Name, "nodes", nodeNames)
 
-	lbName := l.GetLoadBalancerName(ctx, clusterName, service)
-	loadBalancer, err := l.lbOps.GetByName(ctx, lbName)
+	lb, err = l.lbOps.GetByK8SServiceUID(ctx, svc)
 	if err != nil && !errors.Is(err, hcops.ErrNotFound) {
-		return nil, err
+		return nil, fmt.Errorf("%s: %v", op, err)
 	}
 
+	// Try the load balancer's name if we were not able to find it using the
+	// service UID. This is required for two reasons:
+	//
+	// 1. Migration of load balancers which where created before identification
+	// via the service UID was introduced.
+	//
+	// 2. Import of load balancers which were created by other means but
+	// should be re-used by the cloud controller manager.
+	lbName := l.GetLoadBalancerName(ctx, clusterName, svc)
 	if errors.Is(err, hcops.ErrNotFound) {
-		var err error
+		lb, err = l.lbOps.GetByName(ctx, lbName)
+		if err != nil && !errors.Is(err, hcops.ErrNotFound) {
+			return nil, fmt.Errorf("%s: %v", op, err)
+		}
+	}
 
-		loadBalancer, err = l.lbOps.Create(ctx, lbName, service)
+	// If we were still not able to find the load balancer we create it.
+	if errors.Is(err, hcops.ErrNotFound) {
+		lb, err = l.lbOps.Create(ctx, lbName, svc)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", op, err)
 		}
 	}
 
-	lbChanged, err := l.lbOps.ReconcileHCLB(ctx, loadBalancer, service)
+	lbChanged, err := l.lbOps.ReconcileHCLB(ctx, lb, svc)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 	reload = reload || lbChanged
 
-	targetsChanged, err := l.lbOps.ReconcileHCLBTargets(ctx, loadBalancer, service, nodes)
+	targetsChanged, err := l.lbOps.ReconcileHCLBTargets(ctx, lb, svc, nodes)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 	reload = reload || targetsChanged
 
-	servicesChanged, err := l.lbOps.ReconcileHCLBServices(ctx, loadBalancer, service)
+	servicesChanged, err := l.lbOps.ReconcileHCLBServices(ctx, lb, svc)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 	reload = reload || servicesChanged
 
 	if reload {
-		klog.InfoS("reload HC Load Balancer", "op", op, "loadBalancerID", loadBalancer.ID)
-		loadBalancer, err = l.lbOps.GetByID(ctx, loadBalancer.ID)
+		klog.InfoS("reload HC Load Balancer", "op", op, "loadBalancerID", lb.ID)
+		lb, err = l.lbOps.GetByID(ctx, lb.ID)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", op, err)
 		}
 	}
 
-	if err := annotation.LBToService(service, loadBalancer); err != nil {
+	if err := annotation.LBToService(svc, lb); err != nil {
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 
 	// Either set the Hostname or the IPs (below).
 	// See: https://github.com/kubernetes/kubernetes/issues/66607
-	if v, ok := annotation.LBHostname.StringFromService(service); ok {
+	if v, ok := annotation.LBHostname.StringFromService(svc); ok {
 		return &v1.LoadBalancerStatus{
 			Ingress: []v1.LoadBalancerIngress{{Hostname: v}},
 		}, nil
@@ -135,14 +156,14 @@ func (l *loadBalancers) EnsureLoadBalancer(
 
 	var ingress []v1.LoadBalancerIngress
 
-	disablePubNet, err := annotation.LBDisablePublicNetwork.BoolFromService(service)
+	disablePubNet, err := annotation.LBDisablePublicNetwork.BoolFromService(svc)
 	if err != nil && !errors.Is(err, annotation.ErrNotSet) {
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 	if !disablePubNet {
 		ingress = append(ingress,
 			v1.LoadBalancerIngress{
-				IP: loadBalancer.PublicNet.IPv4.IP.String(),
+				IP: lb.PublicNet.IPv4.IP.String(),
 			},
 		// v1.LoadBalancerIngress{
 		// 	IP: loadBalancer.PublicNet.IPv6.IP.String(),
@@ -150,12 +171,12 @@ func (l *loadBalancers) EnsureLoadBalancer(
 		)
 	}
 
-	disablePrivIngress, err := annotation.LBDisablePrivateIngress.BoolFromService(service)
+	disablePrivIngress, err := annotation.LBDisablePrivateIngress.BoolFromService(svc)
 	if err != nil && !errors.Is(err, annotation.ErrNotSet) {
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 	if !disablePrivIngress {
-		for _, nw := range loadBalancer.PrivateNet {
+		for _, nw := range lb.PrivateNet {
 			ingress = append(ingress, v1.LoadBalancerIngress{IP: nw.IP.String()})
 		}
 	}
@@ -164,39 +185,50 @@ func (l *loadBalancers) EnsureLoadBalancer(
 }
 
 func (l *loadBalancers) UpdateLoadBalancer(
-	ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node,
+	ctx context.Context, clusterName string, svc *v1.Service, nodes []*v1.Node,
 ) error {
 	const op = "hcloud/loadBalancers.UpdateLoadBalancer"
+	var (
+		lb  *hcloud.LoadBalancer
+		err error
+	)
 
 	nodeNames := make([]string, len(nodes))
 	for i, n := range nodes {
 		nodeNames[i] = n.Name
 	}
-	klog.InfoS("update Load Balancer", "op", op, "service", service.Name, "nodes", nodeNames)
+	klog.InfoS("update Load Balancer", "op", op, "service", svc.Name, "nodes", nodeNames)
 
-	loadBalancer, err := l.lbOps.GetByName(ctx, l.GetLoadBalancerName(ctx, clusterName, service))
+	lb, err = l.lbOps.GetByK8SServiceUID(ctx, svc)
 	if errors.Is(err, hcops.ErrNotFound) {
-		return nil
+		lbName := l.GetLoadBalancerName(ctx, clusterName, svc)
+
+		lb, err = l.lbOps.GetByName(ctx, lbName)
+		if errors.Is(err, hcops.ErrNotFound) {
+			return nil
+		}
+		// further error types handled below
 	}
 	if err != nil {
 		return fmt.Errorf("%s: %w", op, err)
 	}
-	if _, err := l.lbOps.ReconcileHCLB(ctx, loadBalancer, service); err != nil {
+
+	if _, err = l.lbOps.ReconcileHCLB(ctx, lb, svc); err != nil {
 		return fmt.Errorf("%s: %w", op, err)
 	}
-	if _, err := l.lbOps.ReconcileHCLBTargets(ctx, loadBalancer, service, nodes); err != nil {
+	if _, err = l.lbOps.ReconcileHCLBTargets(ctx, lb, svc, nodes); err != nil {
 		return fmt.Errorf("%s: %w", op, err)
 	}
-	if _, err := l.lbOps.ReconcileHCLBServices(ctx, loadBalancer, service); err != nil {
+	if _, err = l.lbOps.ReconcileHCLBServices(ctx, lb, svc); err != nil {
 		return fmt.Errorf("%s: %w", op, err)
 	}
 	return nil
 }
 
 func (l *loadBalancers) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, service *v1.Service) error {
-	const op = "hcloud/loadBalancer.EnsureLoadBalancerDeleted"
+	const op = "hcloud/loadBalancers.EnsureLoadBalancerDeleted"
 
-	loadBalancer, err := l.lbOps.GetByName(ctx, l.GetLoadBalancerName(ctx, clusterName, service))
+	loadBalancer, err := l.lbOps.GetByK8SServiceUID(ctx, service)
 	if errors.Is(err, hcops.ErrNotFound) {
 		return nil
 	}
@@ -210,11 +242,11 @@ func (l *loadBalancers) EnsureLoadBalancerDeleted(ctx context.Context, clusterNa
 	}
 
 	klog.InfoS("delete Load Balancer", "op", op, "loadBalancerID", loadBalancer.ID)
-	_, err = l.lbs.Delete(ctx, loadBalancer)
+	err = l.lbOps.Delete(ctx, loadBalancer)
+	if errors.Is(err, hcops.ErrNotFound) {
+		return nil
+	}
 	if err != nil {
-		if hcloud.IsError(err, hcloud.ErrorCodeNotFound) {
-			return nil
-		}
 		return fmt.Errorf("%s: %w", op, err)
 	}
 

--- a/internal/hcops/errors.go
+++ b/internal/hcops/errors.go
@@ -2,4 +2,13 @@ package hcops
 
 import "errors"
 
-var ErrNotFound = errors.New("not found")
+var (
+	// ErrNotFound signals that an item was not found by the Hetzner Cloud
+	// backend.
+	ErrNotFound = errors.New("not found")
+
+	// ErrNonUniqueResult signals that more than one matching item was returned
+	// by the Hetzner Cloud backend was returned where only one item was
+	// expected.
+	ErrNonUniqueResult = errors.New("non-unique result")
+)

--- a/internal/hcops/mocks.go
+++ b/internal/hcops/mocks.go
@@ -30,6 +30,11 @@ func (m *MockLoadBalancerOps) Create(
 	return mocks.GetLoadBalancerPtr(args, 0), args.Error(1)
 }
 
+func (m *MockLoadBalancerOps) Delete(ctx context.Context, lb *hcloud.LoadBalancer) error {
+	args := m.Called(ctx, lb)
+	return args.Error(0)
+}
+
 func (m *MockLoadBalancerOps) ReconcileHCLB(
 	ctx context.Context, lb *hcloud.LoadBalancer, svc *v1.Service,
 ) (bool, error) {
@@ -49,4 +54,9 @@ func (m *MockLoadBalancerOps) ReconcileHCLBServices(
 ) (bool, error) {
 	args := m.Called(ctx, lb, svc)
 	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockLoadBalancerOps) GetByK8SServiceUID(ctx context.Context, svc *v1.Service) (*hcloud.LoadBalancer, error) {
+	args := m.Called(ctx, svc)
+	return mocks.GetLoadBalancerPtr(args, 0), args.Error(1)
 }

--- a/internal/mocks/casts.go
+++ b/internal/mocks/casts.go
@@ -29,6 +29,14 @@ func GetLoadBalancerPtr(args mock.Arguments, i int) *hcloud.LoadBalancer {
 	return v.(*hcloud.LoadBalancer)
 }
 
+func getLoadBalancerPtrS(args mock.Arguments, i int) []*hcloud.LoadBalancer {
+	v := args.Get(i)
+	if v == nil {
+		return nil
+	}
+	return v.([]*hcloud.LoadBalancer)
+}
+
 func getNetworkPtr(args mock.Arguments, i int) *hcloud.Network {
 	v := args.Get(i)
 	if v == nil {

--- a/internal/mocks/loadbalancer.go
+++ b/internal/mocks/loadbalancer.go
@@ -30,6 +30,13 @@ func (m *LoadBalancerClient) Create(
 	return args.Get(0).(hcloud.LoadBalancerCreateResult), getResponsePtr(args, 1), args.Error(2)
 }
 
+func (m *LoadBalancerClient) Update(
+	ctx context.Context, lb *hcloud.LoadBalancer, opts hcloud.LoadBalancerUpdateOpts,
+) (*hcloud.LoadBalancer, *hcloud.Response, error) {
+	args := m.Called(ctx, lb, opts)
+	return GetLoadBalancerPtr(args, 0), getResponsePtr(args, 1), args.Error(2)
+}
+
 func (m *LoadBalancerClient) Delete(ctx context.Context, lb *hcloud.LoadBalancer) (*hcloud.Response, error) {
 	args := m.Called(ctx, lb)
 	return getResponsePtr(args, 0), args.Error(1)
@@ -108,4 +115,11 @@ func (m *LoadBalancerClient) DisablePublicInterface(
 ) (*hcloud.Action, *hcloud.Response, error) {
 	args := m.Called(ctx, lb)
 	return getActionPtr(args, 0), getResponsePtr(args, 1), args.Error(2)
+}
+
+func (m *LoadBalancerClient) AllWithOpts(
+	ctx context.Context, opts hcloud.LoadBalancerListOpts,
+) ([]*hcloud.LoadBalancer, error) {
+	args := m.Called(ctx, opts)
+	return getLoadBalancerPtrS(args, 0), args.Error(1)
 }


### PR DESCRIPTION
This commit adds a hcloud-ccm/service-uid label with the value of the
Kubernetes service UID to each Load Balancer created by the CCM. This
allows to uniquely identify Load Balancers managed by the CCM.

All Load Balancer related operations now use the Kubernetes service UID
to obtain the affected Load Balancer from the Hetzner Cloud Backend.
Thereby, renaming of Load Balancers can now be implemented properly as
the CCM does not need to know the old name of the Load Balancer anymore.

To allow the import of existing load balancers the CCM falls back to the
load-balancer.hetzner.cloud/name if no hcloud-ccm/service-uid label is
set. In this case it adds the label to the Load Balancer during
reconciliation.

Closes #128