### PR TITLE
Test Cloud Controller Manager on k3s 

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -6,9 +6,8 @@ jobs:
     strategy:
       matrix:
         k8s: [ 1.18.13, 1.19.5, 1.20.0 ]
-        networks: [ yes, no ]
       fail-fast: false
-    name: k8s ${{ matrix.k8s }}- networks - ${{ matrix.networks }}
+    name: k8s ${{ matrix.k8s }}
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -18,7 +17,7 @@ jobs:
         env:
           K8S_VERSION: k8s-${{ matrix.k8s }}
           TTS_TOKEN: ${{ secrets.TTS_TOKEN }}
-          USE_NETWORKS: ${{ matrix.networks }}
+          USE_NETWORKS: yes
         run: |
           export HCLOUD_TOKEN=$(./scripts/get-token.sh)
           cat resp.json
@@ -29,9 +28,8 @@ jobs:
     strategy:
       matrix:
         k3s: [ v1.18.13+k3s1, v1.19.5+k3s2, v1.20.0+k3s2 ]
-        networks: [ yes, no ]
       fail-fast: false
-    name: k3s ${{ matrix.k3s }}- networks - ${{ matrix.networks }}
+    name: k3s ${{ matrix.k3s }}
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -41,7 +39,7 @@ jobs:
         env:
           K8S_VERSION: k3s-${{ matrix.k3s }}
           TTS_TOKEN: ${{ secrets.TTS_TOKEN }}
-          USE_NETWORKS: ${{ matrix.networks }}
+          USE_NETWORKS: yes
         run: |
           export HCLOUD_TOKEN=$(./scripts/get-token.sh)
           cat resp.json

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -1,25 +1,49 @@
 name: Run e2e tests
 on: [ push ]
 jobs:
-  test:
+  k8s:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: [ 1.17.14, 1.18.12, 1.19.4, 1.20.0 ]
-        networks: [yes, no]
-    name: ${{ matrix.k8s }}- networks - ${{ matrix.networks }}
+        k8s: [ 1.18.13, 1.19.5, 1.20.0 ]
+        networks: [ yes, no ]
+      fail-fast: false
+    name: k8s ${{ matrix.k8s }}- networks - ${{ matrix.networks }}
     steps:
-    - uses: actions/setup-go@v2
-      with:
-        go-version: '1.15'
-    - uses: actions/checkout@master
-    - name: Run tests
-      env:
-        K8S_VERSION: ${{ matrix.k8s }}
-        TTS_TOKEN: ${{ secrets.TTS_TOKEN }}
-        USE_NETWORKS: ${{ matrix.networks }}
-      run: |
-        export HCLOUD_TOKEN=$(./scripts/get-token.sh)
-        cat resp.json
-        go test $(go list ./... | grep e2etests) -v -timeout 60m
-        ./scripts/delete-token.sh $HCLOUD_TOKEN
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15'
+      - uses: actions/checkout@master
+      - name: Run tests
+        env:
+          K8S_VERSION: k8s-${{ matrix.k8s }}
+          TTS_TOKEN: ${{ secrets.TTS_TOKEN }}
+          USE_NETWORKS: ${{ matrix.networks }}
+        run: |
+          export HCLOUD_TOKEN=$(./scripts/get-token.sh)
+          cat resp.json
+          go test $(go list ./... | grep e2etests) -v -timeout 60m
+          ./scripts/delete-token.sh $HCLOUD_TOKEN
+  k3s:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k3s: [ v1.18.13+k3s1, v1.19.5+k3s2, v1.20.0+k3s2 ]
+        networks: [ yes, no ]
+      fail-fast: false
+    name: k3s ${{ matrix.k3s }}- networks - ${{ matrix.networks }}
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15'
+      - uses: actions/checkout@master
+      - name: Run tests
+        env:
+          K8S_VERSION: k3s-${{ matrix.k3s }}
+          TTS_TOKEN: ${{ secrets.TTS_TOKEN }}
+          USE_NETWORKS: ${{ matrix.networks }}
+        run: |
+          export HCLOUD_TOKEN=$(./scripts/get-token.sh)
+          cat resp.json
+          go test $(go list ./... | grep e2etests) -v -timeout 60m
+          ./scripts/delete-token.sh $HCLOUD_TOKEN

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ test:unit:
   stage: E2E
   image: docker:git
   variables:
-    K8S_VERSION: 1.18.12
+    K8S_VERSION: k8s-1.18.12
   before_script:
     - apk add --no-cache git make musl-dev go openssh-client
   script:
@@ -53,43 +53,43 @@ test:unit:
 k8s-1.17:
   <<: *testk8se2e
   variables:
-    K8S_VERSION: 1.17.14
+    K8S_VERSION: k8s-1.17.14
 
 k8s-1.17 networks:
   <<: *testk8se2e
   variables:
-    K8S_VERSION: 1.17.14
+    K8S_VERSION: k8s-1.17.14
     USE_NETWORKS: "yes"
 
 k8s-1.18:
   <<: *testk8se2e
   variables:
-    K8S_VERSION: 1.18.12
+    K8S_VERSION: k8s-1.18.12
 
 k8s-1.18 networks:
   <<: *testk8se2e
   variables:
-    K8S_VERSION: 1.18.12
+    K8S_VERSION: k8s-1.18.12
     USE_NETWORKS: "yes"
 
 k8s-1.19:
   <<: *testk8se2e
   variables:
-    K8S_VERSION: 1.19.4
+    K8S_VERSION: k8s-1.19.4
 
 k8s-1.19 networks:
   <<: *testk8se2e
   variables:
-    K8S_VERSION: 1.19.4
+    K8S_VERSION: k8s-1.19.4
     USE_NETWORKS: "yes"
 
 k8s-1.20:
   <<: *testk8se2e
   variables:
-    K8S_VERSION: 1.20.0
+    K8S_VERSION: k8s-1.20.0
 
 k8s-1.20 networks:
   <<: *testk8se2e
   variables:
-    K8S_VERSION: 1.20.0
+    K8S_VERSION: k8s-1.20.0
     USE_NETWORKS: "yes"

--- a/README.md
+++ b/README.md
@@ -107,12 +107,35 @@ kubectl apply -f  https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-co
 
 ```
 
-If you want to use the Hetzner Cloud `Networks` Feature, head over to the [Deployment with Networks support documentation](./docs/deploy_with_networks.md).
+If you want to use the Hetzner Cloud `Networks` Feature, head over to
+the [Deployment with Networks support documentation](./docs/deploy_with_networks.md).
 
+## Versioning policy
+
+We aim to support the latest three versions of Kubernetes. After a new Kubernetes version has been released we will stop
+supporting the oldest previously supported version. This does not necessarily mean that the Cloud Controller Manager
+does not still work with this version. However, it means that we do not test that version anymore. Additionally, we will
+not fix bugs related only to an unsupported version. We also try to keep compatibility for the respective k3s release
+for a specific Kubernetes release.
+
+| Kubernetes | k3s           | cloud controller Manager   | Networks support | Deployment File                                                                                         |
+| ---------- | -------------:| --------------------------:| -----------------|--------------------------------------------------------------------------------------------------------:|
+| 1.20       | v1.20.0+k3s2  | master                     | Yes              | https://raw.githubusercontent.com/hcloud-cloud-controller-manager/blob/master/deploy/ccm-networks.yaml  |
+| 1.19       | v1.19.5+k3s2  | 1.8.1, master              | Yes              | https://raw.githubusercontent.com/hcloud-cloud-controller-manager/blob/v1.8.1/deploy/ccm-networks.yaml  |
+| 1.18       | v1.18.13+k3s1 | 1.8.1, master              | Yes              | https://raw.githubusercontent.com/hcloud-cloud-controller-manager/blob/v1.8.1/deploy/ccm-networks.yaml  |
+| ---------- | -------------:| ---------------------------|------------------|--------------------------------------------------------------------------------------------------------:|
+| 1.20       | v1.20.0+k3s2  | master                     | No               | https://raw.githubusercontent.com/hcloud-cloud-controller-manager/blob/master/deploy/ccm.yaml           |
+| 1.19       | v1.19.5+k3s2  | 1.8.1, master              | No               | https://raw.githubusercontent.com/hcloud-cloud-controller-manager/blob/v1.8.1/deploy/ccm.yaml           |
+| 1.18       | v1.18.13+k3s1 | 1.8.1, master              | No               | https://raw.githubusercontent.com/hcloud-cloud-controller-manager/blob/v1.8.1/deploy/ccm.yaml           |
 
 ## E2E Tests
 
-The Hetzner Cloud cloud controller manager was tested against all supported Kubernetes versions. You can run the tests with the following commands. Keep in mind, that these tests run on real cloud servers and will create Load Balancers that will be billed.
+The Hetzner Cloud cloud controller manager was tested against all supported Kubernetes versions. We also test against
+the same k3s releases (Sample: When we support testing against Kubernetes 1.20.x we also try to support k3s 1.20.x). We
+try to keep compatibility to k3s but never guarantee this.
+
+You can run the tests with the following commands. Keep in mind, that these tests run on real cloud servers and will
+create Load Balancers that will be billed.
 
 **Test Server Setup:**
 1x CPX21 (Ubuntu 18.04)
@@ -123,7 +146,7 @@ The Hetzner Cloud cloud controller manager was tested against all supported Kube
 
 ```bash
 export HCLOUD_TOKEN=<specifiy a project token>
-export K8S_VERSION=1.20.0 # The specific (latest) version is needed here
+export K8S_VERSION=k8s-1.20.0 # The specific (latest) version is needed here
 export USE_SSH_KEYS=key1,key2 # Name or IDs of your SSH Keys within the Hetzner Cloud, the servers will be accessable with that keys
 export USE_NETWORKS=yes # if `yes` this identidicates that the tests should provision the server with cilium as CNI and also enable the Network related tests
 ## Optional configuration env vars:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ the [Deployment with Networks support documentation](./docs/deploy_with_networks
 We aim to support the latest three versions of Kubernetes. After a new Kubernetes version has been released we will stop
 supporting the oldest previously supported version. This does not necessarily mean that the Cloud Controller Manager
 does not still work with this version. However, it means that we do not test that version anymore. Additionally, we will
-not fix bugs related only to an unsupported version. We also try to keep compatibility for the respective k3s release
+not fix bugs related only to an unsupported version. We also try to keep compatibility with the respective k3s release
 for a specific Kubernetes release.
 
 | Kubernetes | k3s           | cloud controller Manager   | Networks support | Deployment File                                                                                         |
@@ -132,7 +132,7 @@ for a specific Kubernetes release.
 
 The Hetzner Cloud cloud controller manager was tested against all supported Kubernetes versions. We also test against
 the same k3s releases (Sample: When we support testing against Kubernetes 1.20.x we also try to support k3s 1.20.x). We
-try to keep compatibility to k3s but never guarantee this.
+try to keep compatibility with k3s but never guarantee this.
 
 You can run the tests with the following commands. Keep in mind, that these tests run on real cloud servers and will
 create Load Balancers that will be billed.

--- a/e2etests/setup.go
+++ b/e2etests/setup.go
@@ -103,16 +103,13 @@ func (s *hcloudK8sSetup) PrepareTestEnv(ctx context.Context, additionalSSHKeys [
 	}
 
 	fmt.Printf("%s Load Image:\n", op)
+	transferCmd := "docker load --input ci-hcloud-ccm.tar"
 	if s.K8sDistribution == K8sDistributionK3s {
-		err = RunCommandOnServer(s.privKey, s.ClusterNode, fmt.Sprintf("ctr -n=k8s.io image import ci-hcloud-ccm.tar"))
-		if err != nil {
-			return fmt.Errorf("%s:  Load image %s", op, err)
-		}
-	} else {
-		err = RunCommandOnServer(s.privKey, s.ClusterNode, fmt.Sprintf("docker load --input ci-hcloud-ccm.tar"))
-		if err != nil {
-			return fmt.Errorf("%s:  Load image %s", op, err)
-		}
+		transferCmd = "ctr -n=k8s.io image import ci-hcloud-ccm.tar"
+	}
+	err = RunCommandOnServer(s.privKey, s.ClusterNode, transferCmd)
+	if err != nil {
+		return fmt.Errorf("%s: Load image %s", op, err)
 	}
 
 	return nil

--- a/e2etests/templates/cloudinit_k3s.txt.tpl
+++ b/e2etests/templates/cloudinit_k3s.txt.tpl
@@ -1,0 +1,25 @@
+#cloud-config
+write_files:
+- content: |
+    net.bridge.bridge-nf-call-ip6tables = 1
+    net.bridge.bridge-nf-call-iptables = 1
+  path: /etc/sysctl.d/k8s.conf
+- content: |
+    alias k="kubectl"
+    alias ksy="kubectl -n kube-system"
+    alias kgp="kubectl get pods"
+    alias kgs="kubectl get services"
+    export HCLOUD_TOKEN={{.HcloudToken}}
+  path: /root/.bashrc
+runcmd:
+- sysctl --system
+- apt install -y apt-transport-https curl
+- export INSTALL_K3S_VERSION={{.K8sVersion}}
+- curl -sfL https://get.k3s.io | sh -s - --disable servicelb --disable traefik --disable-cloud-controller --kubelet-arg="cloud-provider=external" --no-flannel
+- mkdir -p /root/.kube
+- cp -i /etc/rancher/k3s/k3s.yaml /root/.kube/config
+- until KUBECONFIG=/root/.kube/config kubectl get node; do sleep 2;done
+- KUBECONFIG=/root/.kube/config kubectl -n kube-system create secret generic hcloud --from-literal=token={{.HcloudToken}} --from-literal=network={{.HcloudNetwork}}
+# Download and install latest hcloud cli release for easier debugging on host
+- curl -s https://api.github.com/repos/hetznercloud/cli/releases/latest | grep browser_download_url | grep linux-amd64 | cut -d '"' -f 4 | wget -qi -
+- tar xvzf hcloud-linux-amd64.tar.gz && cp hcloud /usr/bin/hcloud && chmod +x /usr/bin/hcloud

--- a/e2etests/templates/cloudinit_k8s.txt.tpl
+++ b/e2etests/templates/cloudinit_k8s.txt.tpl
@@ -36,9 +36,6 @@ runcmd:
 - cp -i /etc/kubernetes/admin.conf /root/.kube/config
 - until KUBECONFIG=/root/.kube/config kubectl get node; do sleep 2;done
 - KUBECONFIG=/root/.kube/config kubectl -n kube-system create secret generic hcloud --from-literal=token={{.HcloudToken}} --from-literal=network={{.HcloudNetwork}}
-# Remove all master taints and labels, this is special for the one-node cluster we use within the tests
-- KUBECONFIG=/root/.kube/config kubectl taint nodes --all node-role.kubernetes.io/master-
-- KUBECONFIG=/root/.kube/config kubectl label nodes --all node-role.kubernetes.io/master-
 # Download and install latest hcloud cli release for easier debugging on host
 - curl -s https://api.github.com/repos/hetznercloud/cli/releases/latest | grep browser_download_url | grep linux-amd64 | cut -d '"' -f 4 | wget -qi -
 - tar xvzf hcloud-linux-amd64.tar.gz && cp hcloud /usr/bin/hcloud && chmod +x /usr/bin/hcloud

--- a/scripts/e2etest-local.sh
+++ b/scripts/e2etest-local.sh
@@ -10,7 +10,7 @@ function test_k8s_version() {
 
     export K8S_VERSION="$1"
 
-    echo "Testing K8S $K8S_VERSION without network support"
+    echo "Testing $K8S_VERSION without network support"
     export USE_NETWORKS="no"
     if ! go test -count=1 -v -timeout 60m ./e2etests; then
         return 2
@@ -18,7 +18,7 @@ function test_k8s_version() {
 
     echo
     echo
-    echo "Testing K8S $K8S_VERSION with network support"
+    echo "Testing $K8S_VERSION with network support"
     export USE_NETWORKS="yes"
     if ! go test -count=1 -v -timeout 60m ./e2etests; then
         return 2
@@ -30,7 +30,7 @@ if [[ -z "$HCLOUD_TOKEN" ]]; then
     exit 1
 fi
 
-K8S_VERSIONS=("1.17.13" "1.18.12" "1.19.4" "1.20.0")
+K8S_VERSIONS=("k8s-1.18.12" "k8s-1.19.4" "k8s-1.20.0" "k3s-v1.20.0+k3s2")
 for v in "${K8S_VERSIONS[@]}"; do
     test_k8s_version "$v"
 done


### PR DESCRIPTION
This MR adds automated testing of the Cloud Controller Manager on k3s. It also removes the testing without Network Support, because the same tests are performed already when testing with Network support. 