### PR TITLE
Remove testing for k8s 1.18 (and k3s 1.18) as written in our Versioning policy

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: [ 1.18.13, 1.19.5, 1.20.0 ]
+        k8s: [ 1.19.10, 1.20.6, 1.21.0 ]
       fail-fast: false
     name: k8s ${{ matrix.k8s }}
     steps:
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k3s: [ v1.18.13+k3s1, v1.19.5+k3s2, v1.20.0+k3s2 ]
+        k3s: [ v1.19.10+k3s1, v1.20.6+k3s1 ]
       fail-fast: false
     name: k3s ${{ matrix.k3s }}
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,3 +93,14 @@ k8s-1.20 networks:
   variables:
     K8S_VERSION: k8s-1.20.0
     USE_NETWORKS: "yes"
+
+k8s-1.21:
+  <<: *testk8se2e
+  variables:
+    K8S_VERSION: k8s-1.21.0
+
+k8s-1.21 networks:
+  <<: *testk8se2e
+  variables:
+    K8S_VERSION: k8s-1.21.0
+    USE_NETWORKS: "yes"

--- a/README.md
+++ b/README.md
@@ -120,13 +120,13 @@ for a specific Kubernetes release.
 
 | Kubernetes | k3s           | cloud controller Manager   | Networks support | Deployment File                                                                                         |
 | ---------- | -------------:| --------------------------:| -----------------|--------------------------------------------------------------------------------------------------------:|
+| 1.21       | -             | master                     | Yes              | https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/ccm-networks.yaml  |
 | 1.20       | v1.20.0+k3s2  | master                     | Yes              | https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/ccm-networks.yaml  |
 | 1.19       | v1.19.5+k3s2  | 1.8.1, master              | Yes              | https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/v1.8.1/deploy/ccm-networks.yaml  |
-| 1.18       | v1.18.13+k3s1 | 1.8.1, master              | Yes              | https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/v1.8.1/deploy/ccm-networks.yaml  |
 | ---------- | -------------:| ---------------------------|------------------|--------------------------------------------------------------------------------------------------------:|
+| 1.21       | -             | master                     | No               | https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/ccm.yaml           |
 | 1.20       | v1.20.0+k3s2  | master                     | No               | https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/ccm.yaml           |
 | 1.19       | v1.19.5+k3s2  | 1.8.1, master              | No               | https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/v1.8.1/deploy/ccm.yaml           |
-| 1.18       | v1.18.13+k3s1 | 1.8.1, master              | No               | https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/v1.8.1/deploy/ccm.yaml           |
 
 ## E2E Tests
 
@@ -146,7 +146,7 @@ create Load Balancers that will be billed.
 
 ```bash
 export HCLOUD_TOKEN=<specifiy a project token>
-export K8S_VERSION=k8s-1.20.0 # The specific (latest) version is needed here
+export K8S_VERSION=k8s-1.21.0 # The specific (latest) version is needed here
 export USE_SSH_KEYS=key1,key2 # Name or IDs of your SSH Keys within the Hetzner Cloud, the servers will be accessable with that keys
 export USE_NETWORKS=yes # if `yes` this identidicates that the tests should provision the server with cilium as CNI and also enable the Network related tests
 ## Optional configuration env vars:

--- a/scripts/e2etest-local.sh
+++ b/scripts/e2etest-local.sh
@@ -30,7 +30,7 @@ if [[ -z "$HCLOUD_TOKEN" ]]; then
     exit 1
 fi
 
-K8S_VERSIONS=("k8s-1.18.12" "k8s-1.19.4" "k8s-1.20.0" "k3s-v1.20.0+k3s2")
+K8S_VERSIONS=("k8s-1.19.10" "k8s-1.20.6" "k3s-v1.20.6+k3s1", "k8s-1.21.0")
 for v in "${K8S_VERSIONS[@]}"; do
     test_k8s_version "$v"
 done


### PR DESCRIPTION
Add testing for k8s 1.21

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>