### PR TITLE
Update version number in examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+v1.9.1
+------
+
+* Fix: add correct version number to config files
+
 v1.9.0
 ------
 

--- a/deploy/ccm-networks.yaml
+++ b/deploy/ccm-networks.yaml
@@ -54,7 +54,7 @@ spec:
           effect: "NoSchedule"
       hostNetwork: true
       containers:
-        - image: hetznercloud/hcloud-cloud-controller-manager:v1.9.0
+        - image: hetznercloud/hcloud-cloud-controller-manager:v1.9.1
           name: hcloud-cloud-controller-manager
           command:
             - "/bin/hcloud-cloud-controller-manager"

--- a/deploy/ccm.yaml
+++ b/deploy/ccm.yaml
@@ -54,7 +54,7 @@ spec:
         - key: "node.kubernetes.io/not-ready"
           effect: "NoSchedule"
       containers:
-        - image: hetznercloud/hcloud-cloud-controller-manager:v1.9.0
+        - image: hetznercloud/hcloud-cloud-controller-manager:v1.9.1
           name: hcloud-cloud-controller-manager
           command:
             - "/bin/hcloud-cloud-controller-manager"

--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -42,7 +42,7 @@ const (
 	hcloudLoadBalancersUsePrivateIP          = "HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP"
 	nodeNameENVVar                           = "NODE_NAME"
 	providerName                             = "hcloud"
-	providerVersion                          = "v1.8.1"
+	providerVersion                          = "v1.9.1"
 )
 
 type cloud struct {


### PR DESCRIPTION
When creating the 1.9.0 release it was forgotten to update the example
version numbers. This commit prepares the 1.9.1 release which sets the
correct version number in all files.