### PR TITLE
Tolerate node-role.kubernetes.io/control-plane:NoSchedule taints

### DIFF
--- a/deploy/ccm-networks.yaml
+++ b/deploy/ccm-networks.yaml
@@ -50,6 +50,8 @@ spec:
         # cloud controller manages should be able to run on masters
         - key: "node-role.kubernetes.io/master"
           effect: NoSchedule
+        - key: "node-role.kubernetes.io/control-plane"
+          effect: NoSchedule
         - key: "node.kubernetes.io/not-ready"
           effect: "NoSchedule"
       hostNetwork: true

--- a/deploy/ccm.yaml
+++ b/deploy/ccm.yaml
@@ -51,6 +51,8 @@ spec:
         # cloud controller manages should be able to run on masters
         - key: "node-role.kubernetes.io/master"
           effect: NoSchedule
+        - key: "node-role.kubernetes.io/control-plane"
+          effect: NoSchedule
         - key: "node.kubernetes.io/not-ready"
           effect: "NoSchedule"
       containers:

--- a/deploy/dev-ccm-networks.yaml
+++ b/deploy/dev-ccm-networks.yaml
@@ -50,6 +50,8 @@ spec:
         # cloud controller manages should be able to run on masters
         - key: "node-role.kubernetes.io/master"
           effect: NoSchedule
+        - key: "node-role.kubernetes.io/control-plane"
+          effect: NoSchedule
         - key: "node.kubernetes.io/not-ready"
           effect: "NoSchedule"
       hostNetwork: true

--- a/deploy/dev-ccm.yaml
+++ b/deploy/dev-ccm.yaml
@@ -51,6 +51,8 @@ spec:
         # cloud controller manages should be able to run on masters
         - key: "node-role.kubernetes.io/master"
           effect: NoSchedule
+        - key: "node-role.kubernetes.io/control-plane"
+          effect: NoSchedule
         - key: "node.kubernetes.io/not-ready"
           effect: "NoSchedule"
       containers:


### PR DESCRIPTION
The Kubernetes project is moving away from offensive wording and as part
of this KEP-2067 was accepted to replace the
`node-role.kubernetes.io/master:NoSchedule` taint with
`node-role.kubernetes.io/control-plane:NoSchedule`.

To be compatible with clusters that already use the new taint this pull
request adds an additional toleration for it. This change can't really
break existing setups because we continue to tolerate the old taint as
well.

Additional links:
- https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md
- https://github.com/kubernetes/enhancements/issues/2067
- https://github.com/kubernetes/kubeadm/issues/2200