### PR TITLE
Fix generation of deployment yamls

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,4 +39,4 @@ release:
   ids: [""]
   draft: true
   extra_files:
-    - glob: "./deploy/ccm-*.yaml"
+    - glob: "./deploy/ccm*.yaml"


### PR DESCRIPTION
This supersedes the 1.10.0-rc1 release which only contained a
ccm-networks.yaml. Otherwise both releases are identical.