### PR TITLE
Support for IPv6 NodeAddresses

### DIFF
--- a/hcloud/instances.go
+++ b/hcloud/instances.go
@@ -161,9 +161,13 @@ func (i *instances) nodeAddresses(ctx context.Context, server *hcloud.Server) []
 	)
 
 	if i.addressFamily == AddressFamilyIPv6 || i.addressFamily == AddressFamilyDualStack {
+		// For a given IPv6 network of 2001:db8:1234::/64, the instance address is 2001:db8:1234::1
+		host_address := server.PublicNet.IPv6.IP
+		host_address[len(host_address)-1] |= 0x01
+
 		addresses = append(
 			addresses,
-			v1.NodeAddress{Type: v1.NodeExternalIP, Address: server.PublicNet.IPv6.IP.String()},
+			v1.NodeAddress{Type: v1.NodeExternalIP, Address: host_address.String()},
 		)
 	}
 

--- a/hcloud/instances_test.go
+++ b/hcloud/instances_test.go
@@ -37,7 +37,7 @@ func TestNodeAddressesByProviderID(t *testing.T) {
 				Name: "node15",
 				PublicNet: schema.ServerPublicNet{
 					IPv6: schema.ServerPublicNetIPv6{
-						IP: "2001:db8::1/64",
+						IP: "2001:db8:1234::/64",
 					},
 					IPv4: schema.ServerPublicNetIPv4{
 						IP: "131.232.99.1",
@@ -73,7 +73,7 @@ func TestNodeAddresses(t *testing.T) {
 					Name: "node15",
 					PublicNet: schema.ServerPublicNet{
 						IPv6: schema.ServerPublicNetIPv6{
-							IP: "2001:db8::1",
+							IP: "2001:db8:1234::",
 						},
 						IPv4: schema.ServerPublicNetIPv4{
 							IP: "131.232.99.1",
@@ -110,7 +110,7 @@ func TestNodeAddressesIPv6(t *testing.T) {
 					Name: "node15",
 					PublicNet: schema.ServerPublicNet{
 						IPv6: schema.ServerPublicNetIPv6{
-							IP: "2001:db8::1/64",
+							IP: "2001:db8:1234::/64",
 						},
 						IPv4: schema.ServerPublicNetIPv4{
 							IP: "131.232.99.1",
@@ -128,7 +128,7 @@ func TestNodeAddressesIPv6(t *testing.T) {
 	}
 	if len(addr) != 2 ||
 		addr[0].Type != v1.NodeHostName || addr[0].Address != "node15" ||
-		addr[1].Type != v1.NodeExternalIP || addr[1].Address != "2001:db8::1" {
+		addr[1].Type != v1.NodeExternalIP || addr[1].Address != "2001:db8:1234::1" {
 		t.Errorf("Unexpected node addresses: %v", addr)
 	}
 }
@@ -147,7 +147,7 @@ func TestNodeAddressesDualStack(t *testing.T) {
 					Name: "node15",
 					PublicNet: schema.ServerPublicNet{
 						IPv6: schema.ServerPublicNetIPv6{
-							IP: "2001:db8::1/64",
+							IP: "2001:db8:1234::/64",
 						},
 						IPv4: schema.ServerPublicNetIPv4{
 							IP: "131.232.99.1",
@@ -165,7 +165,7 @@ func TestNodeAddressesDualStack(t *testing.T) {
 	}
 	if len(addr) != 3 ||
 		addr[0].Type != v1.NodeHostName || addr[0].Address != "node15" ||
-		addr[1].Type != v1.NodeExternalIP || addr[1].Address != "2001:db8::1" ||
+		addr[1].Type != v1.NodeExternalIP || addr[1].Address != "2001:db8:1234::1" ||
 		addr[2].Type != v1.NodeExternalIP || addr[2].Address != "131.232.99.1" {
 		t.Errorf("Unexpected node addresses: %v", addr)
 	}


### PR DESCRIPTION
This PR adds support for setting an IPv6 address of the node for IPv6-only and dualstack clusters behind an optional environment variable which defaults to IPv4-only.

Context is [this Terraform module](https://github.com/tibordp/terraform-hcloud-dualstack-k8s) which sets up a dual-stack cluster on Hetzner Cloud. The [network plugin](https://github.com/tibordp/wigglenet) that it uses needs instance addresses in order to identify where to terminate the Wireguard tunnel for pod-to-pod traffic and if the primary address family for the cluster is IPv6, it makes sense for the ExternalIP addresses to be also.