### PR TITLE
Add Master is attached to configured Network check on controller boot.

### DIFF
--- a/e2etests/testing.go
+++ b/e2etests/testing.go
@@ -120,7 +120,7 @@ func (tc *TestCluster) initialize() error {
 		err := runCmd(
 			"go",
 			[]string{"build", "-o", "../hcloud-cloud-controller-manager", "../."},
-			[]string{"CGO_ENABLED=0"},
+			[]string{"CGO_ENABLED=0", "GOOS=linux", "GOARCH=amd64"},
 		)
 		if err != nil {
 			return fmt.Errorf("%s: %v", op, err)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/golang/groupcache v0.0.0-20171101203131-84a468cf14b4 // indirect
-	github.com/hetznercloud/hcloud-go v1.25.0
+	github.com/hetznercloud/hcloud-go v1.26.2
 	github.com/stretchr/testify v1.7.0
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2

--- a/go.sum
+++ b/go.sum
@@ -298,8 +298,8 @@ github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible/go.mod h1:bB9ly3RchcQqsQ9CpyaQwvva7RS5ytVoSoholZQON6o=
 github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6/go.mod h1:xGMAM8JLi7UkZt1i4FQeQy0R2T8GLUwQhOP5M1gBhy4=
-github.com/hetznercloud/hcloud-go v1.25.0 h1:QAaFKtGKWRxjwjKJWBGMxGYUxVEQmIkb35j/WXrsazY=
-github.com/hetznercloud/hcloud-go v1.25.0/go.mod h1:2C5uMtBiMoFr3m7lBFPf7wXTdh33CevmZpQIIDPGYJI=
+github.com/hetznercloud/hcloud-go v1.26.2 h1:fI8BXAGJI4EFeCDd2a/I4EhqyK32cDdxGeWfYMGUi50=
+github.com/hetznercloud/hcloud-go v1.26.2/go.mod h1:2C5uMtBiMoFr3m7lBFPf7wXTdh33CevmZpQIIDPGYJI=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=

--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -96,7 +96,12 @@ func newCloud(config io.Reader) (cloudprovider.Interface, error) {
 			return nil, fmt.Errorf("%s: Network %s not found", op, v)
 		}
 		networkID = n.ID
-		if networkDisableAttachedCheck := os.Getenv(hcloudNetworkDisableAttachedCheckENVVar); networkDisableAttachedCheck != "true" {
+
+		networkDisableAttachedCheck, err := getEnvBool(hcloudNetworkDisableAttachedCheckENVVar)
+		if err != nil {
+			return nil, fmt.Errorf("%s: checking if server is in Network not possible: %w", op, err)
+		}
+		if !networkDisableAttachedCheck {
 			e, err := serverIsAttachedToNetwork(networkID)
 			if err != nil {
 				return nil, fmt.Errorf("%s: checking if server is in Network not possible: %w", op, err)
@@ -229,7 +234,7 @@ func serverIsAttachedToNetwork(networkId int) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("%s: %s", op, err)
 	}
-	return strings.Contains(string(body), fmt.Sprintf("network_id: %d", networkId)), nil
+	return strings.Contains(string(body), fmt.Sprintf("network_id: %d\n", networkId)), nil
 }
 
 // getEnvBool returns the boolean parsed from the environment variable with the given key and a potential error

--- a/hcloud/cloud_test.go
+++ b/hcloud/cloud_test.go
@@ -233,10 +233,13 @@ func TestCloud(t *testing.T) {
 	})
 
 	t.Run("RoutesWithNetworks", func(t *testing.T) {
-		resetEnv := Setenv(t, "HCLOUD_NETWORK", "1")
+		resetEnv := Setenv(t, "HCLOUD_NETWORK", "1", "HCLOUD_NETWORK_DISABLE_ATTACHED_CHECK", "true")
 		defer resetEnv()
 
-		c, _ := newCloud(&bytes.Buffer{})
+		c, err := newCloud(&bytes.Buffer{})
+		if err != nil {
+			t.Errorf("%s", err)
+		}
 		_, supported := c.Routes()
 		if !supported {
 			t.Error("Routes interface should be supported")


### PR DESCRIPTION
We had several reports/issues from customers who configured there CCM wrong. They copied there configuration and changed nothing (It uses the same API token and the configured network as the other cluster). However, the servers of the new cluster were in a different project and/or attached to a different network. Because of this, two CCM instances started to fight against each other, because the CCM always tries to reach the wanted state in the network, so it detaches everything it does not know about and then attaches his "known" routes.

With this MR we now check if the master is attached to the configured network by using a "not user controllable" source of truth - our metadata service, that is only reachable through the node public interface. This check will be performed on boot and if the node is not attached to the correct network, it will fail booting up with a message that gives this hint. I also added a new ENV to disable this check for cluster specific reasons (sample: Rancher clusters where the controlplan might be out of the cluster itself). We decided to check this "per default", so there might be issues for customers who have currently a somehow broken cluster but didn't noticed it.

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>