### PR TITLE
fix release asset version for docker image tag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
     ldflags:
       - "-s -w -X hcloud.providerVersion={{ if not .IsSnapshot }}v{{ end }}{{ .Version }}"
     hooks:
-      post: ./scripts/generate-deployment-yamls.sh {{ .Version }}
+      post: "./scripts/generate-deployment-yamls.sh {{ if not .IsSnapshot }}v{{ end }}{{ .Version }}"
 archives:
   - id: deployment-yamls
     # builds: [""]


### PR DESCRIPTION
Currently the generated release assets (`ccm.yaml` and `ccm-networks.yaml`) do not include the "v" prefix of the build docker image tag.

e.g. for current release (v1.11.0):
https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/v1.11.0/ccm.yaml (image tag without "v" prefix)
https://hub.docker.com/layers/hetznercloud/hcloud-cloud-controller-manager/v1.11.0/images/sha256-3e6f91a79693a9b7deaa415b89513919fd734c1a444e16eca9cfbe9cc82cb7c9 (image tag with "v" prefix)