### PR TITLE
Explain --cloud-provider=external a bit more

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,16 +78,19 @@ which these instructions are meant to argument and the [kubeadm
 documentation](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm/).
 
 1. The cloud controller manager adds its labels when a node is added to
-   the cluster. This means we have to add the
-   `--cloud-provider=external` flag to the `kubelet` before initializing
-   the cluster master with `kubeadm init`.  To do accomplish this we add
-   this systemd drop-in unit:
-   `/etc/systemd/system/kubelet.service.d/20-hcloud.conf`
+   the cluster. For Kubernetes versions prior to 1.23, this means we
+   have to add the `--cloud-provider=external` flag to the `kubelet`
+   before initializing the cluster master with `kubeadm init`. To do
+   accomplish this we add this systemd drop-in unit
+   `/etc/systemd/system/kubelet.service.d/20-hcloud.conf`:
 
     ```
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--cloud-provider=external"
     ```
+
+    Note: the `--cloud-provider` flag is deprecated since K8S 1.19. You
+    will see a log message regarding this.
 
 2. Now the cluster master can be initialized:
 

--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -60,7 +60,7 @@ func providerIDToServerID(providerID string) (int, error) {
 
 	providerPrefix := providerName + "://"
 	if !strings.HasPrefix(providerID, providerPrefix) {
-		klog.Infof("%s: make sure your cluster was initialized with kubelet arg --cloud-provider=external", op)
+		klog.Infof("%s: make sure your cluster configured for an external cloud provider", op)
 		return 0, fmt.Errorf("%s: missing prefix hcloud://: %s", op, providerID)
 	}
 


### PR DESCRIPTION
Add an explanation to the README explaining why a deprecation warning may occur. Once Kubernetes 1.23 is ready we will need to look into how this is supposed to work in the future. At the moment it seems like the cloud provider flag is going to be [removed completely](https://github.com/kubernetes/kubernetes/pull/90408#issuecomment-670057176) and can just be left out.

Closes #189 