### PR TITLE
Adds opportunity to use ipv6 more flexible

### DIFF
--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -40,6 +40,7 @@ const (
 	hcloudLoadBalancersNetworkZone           = "HCLOUD_LOAD_BALANCERS_NETWORK_ZONE"
 	hcloudLoadBalancersDisablePrivateIngress = "HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS"
 	hcloudLoadBalancersUsePrivateIP          = "HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP"
+	hcloudLoadBalancersDisableIPv6		 = "HCLOUD_LOAD_BALANCERS_DISABLE_IPV6"
 	nodeNameENVVar                           = "NODE_NAME"
 	providerName                             = "hcloud"
 	providerVersion                          = "v1.9.1"

--- a/hcloud/load_balancers.go
+++ b/hcloud/load_balancers.go
@@ -70,11 +70,11 @@ func (l *loadBalancers) GetLoadBalancer(
 		return nil, false, fmt.Errorf("%s",err)
 	}
 	disableipv6Annotation, err := annotation.LBIPv6Disabled.BoolFromService(service)
-	if err != nil {
+	if err != nil && !errors.Is(err, annotation.ErrNotSet) {
 		return nil, false, fmt.Errorf("%s",err)
 	}
 	enableipv6Annotation, err := annotation.LBIPv6Enabled.BoolFromService(service)
-	if err != nil {
+	if err != nil && !errors.Is(err, annotation.ErrNotSet) {
 		return nil, false, fmt.Errorf("%s",err)
 	}
 	if !disableIPV6 || !disableipv6Annotation || enableipv6Annotation {
@@ -191,11 +191,11 @@ func (l *loadBalancers) EnsureLoadBalancer(
 			return nil, fmt.Errorf("%s",err)
 		}
 		disableipv6Annotation, err := annotation.LBIPv6Disabled.BoolFromService(svc)
-		if err != nil {
+		if err != nil && !errors.Is(err, annotation.ErrNotSet) {
 			return nil, fmt.Errorf("%s",err)
 		}
 		enableipv6Annotation, err := annotation.LBIPv6Enabled.BoolFromService(svc)
-		if err != nil {
+		if err != nil && !errors.Is(err, annotation.ErrNotSet) {
 			return nil, false, fmt.Errorf("%s",err)
 		}
 		if !disableIPV6 || disableipv6Annotation || enableipv6Annotation {

--- a/hcloud/load_balancers.go
+++ b/hcloud/load_balancers.go
@@ -190,11 +190,11 @@ func (l *loadBalancers) EnsureLoadBalancer(
 		if err != nil {
 			return nil, fmt.Errorf("%s",err)
 		}
-		disableipv6Annotation, err := annotation.LBIPv6Disabled.BoolFromService(service)
+		disableipv6Annotation, err := annotation.LBIPv6Disabled.BoolFromService(svc)
 		if err != nil {
 			return nil, fmt.Errorf("%s",err)
 		}
-		enableipv6Annotation, err := annotation.LBIPv6Enabled.BoolFromService(service)
+		enableipv6Annotation, err := annotation.LBIPv6Enabled.BoolFromService(svc)
 		if err != nil {
 			return nil, false, fmt.Errorf("%s",err)
 		}

--- a/internal/annotation/load_balancer.go
+++ b/internal/annotation/load_balancer.go
@@ -27,6 +27,11 @@ const (
 	// Default: false
 	LBIPv6Disabled Name = "load-balancer.hetzner.cloud/ipv6-disabled"
 
+	// LBIPv6Enabled enables the use of IPv6 for the Load Balancer.
+	//
+	// Default: false
+	LBIPv6Enabled Name = "load-balancer.hetzner.cloud/ipv6-enabled"
+
 	// LBName is the name of the Load Balancer. The name will be visible in
 	// the Hetzner Cloud API console.
 	LBName Name = "load-balancer.hetzner.cloud/name"


### PR DESCRIPTION
I implemented a feature to fix #233.

Now you can set a default with an environment variable named ```HCLOUD_LOAD_BALANCERS_DISABLE_IPV6```. 
But you still have the possibility to enable or disable ipv6 on individual services with following annotations:
```load-balancer.hetzner.cloud/ipv6-disabled```(noting new)
```load-balancer.hetzner.cloud/ipv6-enabled``` (If you would like to enable ipv6 on a specific service after you disabled ipv6 globally)


Signed-off-by: Fynn Späker <spaeker@23technologies.cloud>

