### PR TITLE
Bring IPv6 flag in line with private ingress flag

### DIFF
--- a/hcloud/cloud_test.go
+++ b/hcloud/cloud_test.go
@@ -289,7 +289,7 @@ func TestLoadBalancerDefaultsFromEnv(t *testing.T) {
 				UsePrivateIP: true,
 			},
 			expDisablePrivateIngress: true,
-			expDisableIPv6: true,
+			expDisableIPv6:           true,
 		},
 		{
 			name: "Network zone set",

--- a/hcloud/cloud_test.go
+++ b/hcloud/cloud_test.go
@@ -265,6 +265,7 @@ func TestLoadBalancerDefaultsFromEnv(t *testing.T) {
 		env                      map[string]string
 		expDefaults              hcops.LoadBalancerDefaults
 		expDisablePrivateIngress bool
+		expDisableIPv6           bool
 		expErr                   string
 	}{
 		{
@@ -280,6 +281,7 @@ func TestLoadBalancerDefaultsFromEnv(t *testing.T) {
 			env: map[string]string{
 				"HCLOUD_LOAD_BALANCERS_LOCATION":                "hel1",
 				"HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS": "true",
+				"HCLOUD_LOAD_BALANCERS_DISABLE_IPV6":            "true",
 				"HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP":          "true",
 			},
 			expDefaults: hcops.LoadBalancerDefaults{
@@ -287,6 +289,7 @@ func TestLoadBalancerDefaultsFromEnv(t *testing.T) {
 				UsePrivateIP: true,
 			},
 			expDisablePrivateIngress: true,
+			expDisableIPv6: true,
 		},
 		{
 			name: "Network zone set",
@@ -311,6 +314,13 @@ func TestLoadBalancerDefaultsFromEnv(t *testing.T) {
 				"HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS": "invalid",
 			},
 			expErr: `HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS: strconv.ParseBool: parsing "invalid": invalid syntax`,
+		},
+		{
+			name: "Invalid DISABLE_IPV6",
+			env: map[string]string{
+				"HCLOUD_LOAD_BALANCERS_DISABLE_IPV6": "invalid",
+			},
+			expErr: `HCLOUD_LOAD_BALANCERS_DISABLE_IPV6: strconv.ParseBool: parsing "invalid": invalid syntax`,
 		},
 		{
 			name: "Invalid USE_PRIVATE_IP",
@@ -347,7 +357,7 @@ func TestLoadBalancerDefaultsFromEnv(t *testing.T) {
 				}
 			}()
 
-			defaults, disablePrivateIngress, err := loadBalancerDefaultsFromEnv()
+			defaults, disablePrivateIngress, disableIPv6, err := loadBalancerDefaultsFromEnv()
 
 			if c.expErr != "" {
 				assert.EqualError(t, err, c.expErr)
@@ -356,6 +366,7 @@ func TestLoadBalancerDefaultsFromEnv(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, c.expDefaults, defaults)
 			assert.Equal(t, c.expDisablePrivateIngress, disablePrivateIngress)
+			assert.Equal(t, c.expDisableIPv6, disableIPv6)
 		})
 	}
 }

--- a/hcloud/testing.go
+++ b/hcloud/testing.go
@@ -74,6 +74,7 @@ type LoadBalancerTestCase struct {
 	ServiceUID                   string
 	ServiceAnnotations           map[annotation.Name]interface{}
 	DisablePrivateIngressDefault bool
+	DisableIPv6Default           bool
 	Nodes                        []*v1.Node
 	LB                           *hcloud.LoadBalancer
 	LBCreateResult               *hcloud.LoadBalancerCreateResult
@@ -123,7 +124,7 @@ func (tt *LoadBalancerTestCase) run(t *testing.T) {
 		tt.Mock(t, tt)
 	}
 
-	tt.LoadBalancers = newLoadBalancers(tt.LBOps, tt.ActionClient, tt.DisablePrivateIngressDefault)
+	tt.LoadBalancers = newLoadBalancers(tt.LBOps, tt.ActionClient, tt.DisablePrivateIngressDefault, tt.DisableIPv6Default)
 	tt.Perform(t, tt)
 
 	tt.LBOps.AssertExpectations(t)


### PR DESCRIPTION
To implement my own feature request #233 and inspired by @fynluk's take in #236

Unfortunately #236 doesn't work for me, so here's my version.

This models the HCLOUD_LOAD_BALANCERS_DISABLE_IPV6 feature more closely
after how HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS is implemented.

@LKaemmerling @fhofherr I noticed EnsureLoadBalancer() returns the private ingress if enabled while GetLoadBalancer() does not. Is this intentional?