### PR TITLE
Ignore stale routes on RouteList

### DIFF
--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -126,7 +126,7 @@ func newCloud(config io.Reader) (cloudprovider.Interface, error) {
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 
-	fmt.Printf("Hetzner Cloud k8s cloud controller %s started\n", providerVersion)
+	klog.Infof("Hetzner Cloud k8s cloud controller %s started\n", providerVersion)
 
 	lbOps := &hcops.LoadBalancerOps{
 		LBClient:      &client.LoadBalancer,


### PR DESCRIPTION
Sometimes it might happen that routes still exists but the servers to the route are deleted. With this can handle this case easily.

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>

Fixes #225
Fixes #231
Fixes #165