### PR TITLE
Added annotation to select nodes by node label selector

### DIFF
--- a/hcloud/load_balancers.go
+++ b/hcloud/load_balancers.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"reflect"
 
 	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/annotation"
 	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/hcops"
@@ -116,7 +117,7 @@ func MustGetObject(obj interface{}) metav1.Object {
 	panic(fmt.Errorf("Unknown type: %v", reflect.TypeOf(obj)))
 }
 
-func (l *loadBalancers) nodesForService(svc *v1.Service, nodes []*v1.Node) ([]*v1.Node) {
+func (l *loadBalancers) nodesForService(svc *v1.Service, nodes []*v1.Node) []*v1.Node {
 	objectMeta := MustGetObject(svc)
 	svcAnnotations := objectMeta.GetAnnotations()
 
@@ -129,7 +130,7 @@ func (l *loadBalancers) nodesForService(svc *v1.Service, nodes []*v1.Node) ([]*v
 		filteredNodes := []*v1.Node{}
 		for _, n := range nodes {
 			if nodeSelector.Matches(labels.Set(n.Labels)) {
-				filteredNodes = append(filteredNodes,n)
+				filteredNodes = append(filteredNodes, n)
 			}
 		}
 
@@ -150,7 +151,7 @@ func (l *loadBalancers) EnsureLoadBalancer(
 		lb     *hcloud.LoadBalancer
 		err    error
 	)
-	nodes = l.nodesForService(svc,nodes)
+	nodes = l.nodesForService(svc, nodes)
 	nodeNames := make([]string, len(nodes))
 	for i, n := range nodes {
 		nodeNames[i] = n.Name

--- a/internal/annotation/load_balancer.go
+++ b/internal/annotation/load_balancer.go
@@ -185,6 +185,9 @@ const (
 	// LBSvcHealthCheckHTTPStatusCodes is a comma separated list of HTTP status
 	// codes which we expect.
 	LBSvcHealthCheckHTTPStatusCodes Name = "load-balancer.hetzner.cloud/http-status-codes"
+
+	// LBSvcTargetNodesMatching is a comma separated list of label matchers to get a subset of nodes in the cluster.
+	LBSvcTargetNodesMatching Name = "load-balancer.hetzner.cloud/target-nodes-matching"
 )
 
 // LBToService sets the relevant annotations on svc to their respective values


### PR DESCRIPTION
The idea and k8s related functions are from kubernetes-replicator:
https://github.com/mittwald/kubernetes-replicator/blob/master/replicate/common/strings.go#L34-L58

Then add `"load-balancer.hetzner.cloud/target-nodes-matching"` annotation to the service ( e.g. "node-role.kubernetes.io/worker" ). The list of nodes will then be filtered.