### PR TITLE
feat: allow setting of reverse DNS records

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,19 @@ release.
 | 1.21       | v1.21.6+k3s1      | 1.12.0, master           | https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm.yaml |
 | 1.20       | v1.20.12+k3s1     | 1.12.0, master           | https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm.yaml |
 
+## Unit tests
+
+To run unit tests locally, execute
+
+```sh
+go test $(go list ./... | grep -v e2etests) -v
+```
+
+Check that your go version is up to date, tests might fail if it is not.
+
+If in doubt, check which go version the `test:unit` section in `.gitlab-ci.yml`
+has set in the `image: golang:$VERSION`.
+
 ## E2E Tests
 
 The Hetzner Cloud cloud controller manager was tested against all

--- a/internal/annotation/load_balancer.go
+++ b/internal/annotation/load_balancer.go
@@ -16,9 +16,17 @@ const (
 	// the backend. Read-only.
 	LBPublicIPv4 Name = "load-balancer.hetzner.cloud/ipv4"
 
+	// LBPublicIPv4RDNS is the reverse DNS record assigned to the IPv4 address of
+	// the Load Balancer
+	LBPublicIPv4RDNS Name = "load-balancer.hetzner.cloud/ipv4-rdns"
+
 	// LBPublicIPv6 is the public IPv6 address assigned to the Load Balancer by
 	// the backend. Read-only.
 	LBPublicIPv6 Name = "load-balancer.hetzner.cloud/ipv6"
+
+	// LBPublicIPv6RDNS is the reverse DNS record assigned to the IPv6 address of
+	// the Load Balancer
+	LBPublicIPv6RDNS Name = "load-balancer.hetzner.cloud/ipv6-rdns"
 
 	// LBIPv6Disabled disables the use of IPv6 for the Load Balancer.
 	//

--- a/internal/mocks/loadbalancer.go
+++ b/internal/mocks/loadbalancer.go
@@ -63,6 +63,13 @@ func (m *LoadBalancerClient) ChangeAlgorithm(
 	return getActionPtr(args, 0), getResponsePtr(args, 1), args.Error(2)
 }
 
+func (m *LoadBalancerClient) ChangeDNSPtr(
+	ctx context.Context, lb *hcloud.LoadBalancer, ip string, ptr *string,
+) (*hcloud.Action, *hcloud.Response, error) {
+	args := m.Called(ctx, lb, ip, ptr)
+	return getActionPtr(args, 0), getResponsePtr(args, 1), args.Error(2)
+}
+
 func (m *LoadBalancerClient) ChangeType(
 	ctx context.Context, lb *hcloud.LoadBalancer, opts hcloud.LoadBalancerChangeTypeOpts,
 ) (*hcloud.Action, *hcloud.Response, error) {


### PR DESCRIPTION
This allows setting reverse DNS records for the Load Balancer with the annotations:

* `load-balancer.hetzner.cloud/ipv4-rdns` for IPv4 and
* `load-balancer.hetzner.cloud/ipv6-rdns` for IPv6.

As this is my first time working with testify and contributing to this repo, please check the tests I wrote carefully.

They pass, but some feedback if I wrote them correctly would be much appreciated, especially regarding the repeated type conversions in the mocks.