### PR TITLE
Migrate to priorityClassName API

### DIFF
--- a/deploy/ccm-networks.yaml
+++ b/deploy/ccm-networks.yaml
@@ -34,8 +34,6 @@ spec:
     metadata:
       labels:
         app: hcloud-cloud-controller-manager
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       serviceAccountName: cloud-controller-manager
       dnsPolicy: Default
@@ -86,3 +84,4 @@ spec:
                 secretKeyRef:
                   name: hcloud
                   key: network
+      priorityClassName: system-cluster-critical

--- a/deploy/ccm-networks.yaml.tmpl
+++ b/deploy/ccm-networks.yaml.tmpl
@@ -34,8 +34,6 @@ spec:
     metadata:
       labels:
         app: hcloud-cloud-controller-manager
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       serviceAccountName: cloud-controller-manager
       dnsPolicy: Default
@@ -86,3 +84,4 @@ spec:
                 secretKeyRef:
                   name: hcloud
                   key: network
+      priorityClassName: system-cluster-critical

--- a/deploy/ccm.yaml
+++ b/deploy/ccm.yaml
@@ -35,8 +35,6 @@ spec:
     metadata:
       labels:
         app: hcloud-cloud-controller-manager
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       serviceAccountName: cloud-controller-manager
       dnsPolicy: Default
@@ -79,3 +77,4 @@ spec:
                 secretKeyRef:
                   name: hcloud
                   key: token
+      priorityClassName: system-cluster-critical

--- a/deploy/ccm.yaml.tmpl
+++ b/deploy/ccm.yaml.tmpl
@@ -35,8 +35,6 @@ spec:
     metadata:
       labels:
         app: hcloud-cloud-controller-manager
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       serviceAccountName: cloud-controller-manager
       dnsPolicy: Default
@@ -77,3 +75,4 @@ spec:
                 secretKeyRef:
                   name: hcloud
                   key: token
+      priorityClassName: system-cluster-critical

--- a/deploy/dev-ccm-networks.yaml
+++ b/deploy/dev-ccm-networks.yaml
@@ -34,8 +34,6 @@ spec:
     metadata:
       labels:
         app: hcloud-cloud-controller-manager
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       serviceAccountName: cloud-controller-manager
       dnsPolicy: Default
@@ -86,3 +84,4 @@ spec:
                 secretKeyRef:
                   name: hcloud
                   key: network
+      priorityClassName: system-cluster-critical

--- a/deploy/dev-ccm.yaml
+++ b/deploy/dev-ccm.yaml
@@ -35,8 +35,6 @@ spec:
     metadata:
       labels:
         app: hcloud-cloud-controller-manager
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       serviceAccountName: cloud-controller-manager
       dnsPolicy: Default
@@ -79,3 +77,4 @@ spec:
                 secretKeyRef:
                   name: hcloud
                   key: token
+      priorityClassName: system-cluster-critical


### PR DESCRIPTION
When I tried to install [the latest ccm.yaml](https://github.com/hetznercloud/hcloud-cloud-controller-manager/blob/main/deploy/ccm.yaml) onto a new Hetzner node running latest k3s + 1.22.7 I was surprised to get the following warning:
```
$ kubectl apply -f https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm.yaml
serviceaccount/cloud-controller-manager created
clusterrolebinding.rbac.authorization.k8s.io/system:cloud-controller-manager created
Warning: spec.template.metadata.annotations[scheduler.alpha.kubernetes.io/critical-pod]: non-functional in v1.16+; use the "priorityClassName" field instead
deployment.apps/hcloud-cloud-controller-manager created
```
This simple PR attempts to use the recommended replacement API.

Because the `critical-pod` annotation is non functional in v1.16+, but we still want to specify how important this pod is, we set `priorityClassName` to `system-cluster-critical`. This should have a similar effect as before, AFAICT.

NB: I haven't tested this on any version of k8s beyond `v1.22.7.` 
```shell
$ kubectl apply -f deploy/ccm.yaml 
serviceaccount/cloud-controller-manager unchanged
clusterrolebinding.rbac.authorization.k8s.io/system:cloud-controller-manager unchanged
deployment.apps/hcloud-cloud-controller-manager configured
```

[More](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#marking-pod-as-critical)