### PR TITLE
Prioritize IPv4 address family by dual-stack

### DIFF
--- a/hcloud/instances.go
+++ b/hcloud/instances.go
@@ -169,6 +169,15 @@ func (i *instances) nodeAddresses(ctx context.Context, server *hcloud.Server) []
 		v1.NodeAddress{Type: v1.NodeHostName, Address: server.Name},
 	)
 
+	if i.addressFamily == AddressFamilyIPv4 || i.addressFamily == AddressFamilyDualStack {
+		if !server.PublicNet.IPv4.IP.IsUnspecified() {
+			addresses = append(
+				addresses,
+				v1.NodeAddress{Type: v1.NodeExternalIP, Address: server.PublicNet.IPv4.IP.String()},
+			)
+		}
+	}
+
 	if i.addressFamily == AddressFamilyIPv6 || i.addressFamily == AddressFamilyDualStack {
 		if !server.PublicNet.IPv6.IP.IsUnspecified() {
 			// For a given IPv6 network of 2001:db8:1234::/64, the instance address is 2001:db8:1234::1
@@ -178,15 +187,6 @@ func (i *instances) nodeAddresses(ctx context.Context, server *hcloud.Server) []
 			addresses = append(
 				addresses,
 				v1.NodeAddress{Type: v1.NodeExternalIP, Address: host_address.String()},
-			)
-		}
-	}
-
-	if i.addressFamily == AddressFamilyIPv4 || i.addressFamily == AddressFamilyDualStack {
-		if !server.PublicNet.IPv4.IP.IsUnspecified() {
-			addresses = append(
-				addresses,
-				v1.NodeAddress{Type: v1.NodeExternalIP, Address: server.PublicNet.IPv4.IP.String()},
 			)
 		}
 	}

--- a/hcloud/instances_test.go
+++ b/hcloud/instances_test.go
@@ -165,8 +165,8 @@ func TestNodeAddressesDualStack(t *testing.T) {
 	}
 	if len(addr) != 3 ||
 		addr[0].Type != v1.NodeHostName || addr[0].Address != "node15" ||
-		addr[1].Type != v1.NodeExternalIP || addr[1].Address != "2001:db8:1234::1" ||
-		addr[2].Type != v1.NodeExternalIP || addr[2].Address != "131.232.99.1" {
+		addr[1].Type != v1.NodeExternalIP || addr[1].Address != "131.232.99.1" ||
+		addr[2].Type != v1.NodeExternalIP || addr[2].Address != "2001:db8:1234::1" {
 		t.Errorf("Unexpected node addresses: %v", addr)
 	}
 }


### PR DESCRIPTION
This is a quick-fix / enhancement for the issue described in https://github.com/hetznercloud/hcloud-cloud-controller-manager/issues/305

Switches the order of the node `ExternalIP` list to favour IPv4, as most of the dual-stack k8s clusters probably will be mostly relying on IPv4 control plane before apiserver properly supports dual-stack.

Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>