### PR TITLE
Fix PTR update for load balancer

### DIFF
--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -368,7 +368,7 @@ func (l *LoadBalancerOps) changeIPv4RDNS(ctx context.Context, lb *hcloud.LoadBal
 		return false, nil
 	}
 
-	action, _, err := l.LBClient.ChangeDNSPtr(ctx, lb, string(lb.PublicNet.IPv4.IP), &rdns)
+	action, _, err := l.LBClient.ChangeDNSPtr(ctx, lb, lb.PublicNet.IPv4.IP.String(), &rdns)
 
 	if err != nil {
 		return false, fmt.Errorf("%s: %w", op, err)
@@ -394,7 +394,7 @@ func (l *LoadBalancerOps) changeIPv6RDNS(ctx context.Context, lb *hcloud.LoadBal
 		return false, nil
 	}
 
-	action, _, err := l.LBClient.ChangeDNSPtr(ctx, lb, string(lb.PublicNet.IPv6.IP), &rdns)
+	action, _, err := l.LBClient.ChangeDNSPtr(ctx, lb, lb.PublicNet.IPv6.IP.String(), &rdns)
 
 	if err != nil {
 		return false, fmt.Errorf("%s: %w", op, err)

--- a/internal/hcops/load_balancer_test.go
+++ b/internal/hcops/load_balancer_test.go
@@ -772,7 +772,7 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 			mock: func(t *testing.T, tt *LBReconcilementTestCase) {
 				action := &hcloud.Action{ID: rand.Int()}
 				newRDNS := "new-name-lb.example.com"
-				tt.fx.LBClient.On("ChangeDNSPtr", tt.fx.Ctx, tt.initialLB, string(net.ParseIP("1.2.3.4")), &newRDNS).Return(action, nil, nil)
+				tt.fx.LBClient.On("ChangeDNSPtr", tt.fx.Ctx, tt.initialLB, net.ParseIP("1.2.3.4").String(), &newRDNS).Return(action, nil, nil)
 				tt.fx.MockWatchProgress(action, nil)
 			},
 			perform: func(t *testing.T, tt *LBReconcilementTestCase) {
@@ -819,7 +819,7 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 			mock: func(t *testing.T, tt *LBReconcilementTestCase) {
 				action := &hcloud.Action{ID: rand.Int()}
 				newRDNS := "new-name-lb.example.com"
-				tt.fx.LBClient.On("ChangeDNSPtr", tt.fx.Ctx, tt.initialLB, string(net.ParseIP("fe80::1")), &newRDNS).Return(action, nil, nil)
+				tt.fx.LBClient.On("ChangeDNSPtr", tt.fx.Ctx, tt.initialLB, net.ParseIP("fe80::1").String(), &newRDNS).Return(action, nil, nil)
 				tt.fx.MockWatchProgress(action, nil)
 			},
 			perform: func(t *testing.T, tt *LBReconcilementTestCase) {


### PR DESCRIPTION
IPv4.IP is `net.IP`, we should use `.String()` instead.

This should be able to fix the errors below:

```
E0915 21:16:48.820450       1 controller.go:310] error processing service traefik/traefik (will retry): failed to ensure load balancer: hcloud/loadBalancers.EnsureLoadBalancer: hcops/LoadBalancerOps.ReconcileHCLB: hcops/LoadBalancerOps.changeIPv4RDNS: could not parse ip address �����
I0915 21:16:46.665718       1 event.go:294] "Event occurred" object="haproxy/haproxy-private-cache-4-kubernetes-ingress" fieldPath="" kind="Service" apiVersion="v1" type="Warning" reason="SyncLoadBalancerFailed" message="Error syncing load balancer: failed to ensure load balancer: hcloud/loadBalancers.EnsureLoadBalancer: hcops/LoadBalancerOps.ReconcileHCLB: hcops/LoadBalancerOps.changeIPv4RDNS: could not parse ip address \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x05\xa1\xa0{"
````