### PR TITLE
fix: allow to provide tls port for health checks

### DIFF
--- a/hcloud/instances.go
+++ b/hcloud/instances.go
@@ -206,5 +206,6 @@ func (i *instances) nodeAddresses(ctx context.Context, server *hcloud.Server) []
 
 		}
 	}
+
 	return addresses
 }

--- a/internal/annotation/load_balancer.go
+++ b/internal/annotation/load_balancer.go
@@ -186,6 +186,10 @@ const (
 	// performing the health check.
 	LBSvcHealthCheckHTTPPath Name = "load-balancer.hetzner.cloud/health-check-http-path"
 
+	// LBSvcHealthCheckTLSPort specifies the port for which to enable TLS
+	// performing the health check.
+	LBSvcHealthCheckTLSPort Name = "load-balancer.hetzner.cloud/health-check-tls-port"
+
 	// LBSvcHealthCheckHTTPValidateCertificate specifies whether the health
 	// check should validate the SSL certificate that comes from the target
 	// nodes.
@@ -256,6 +260,7 @@ func LBToService(svc *v1.Service, lb *hcloud.LoadBalancer) error {
 			sa.Annotate(LBSvcHealthCheckHTTPPath, hclbService.HealthCheck.HTTP.Path)
 			sa.Annotate(LBSvcHealthCheckHTTPStatusCodes, hclbService.HealthCheck.HTTP.StatusCodes)
 		}
+
 		if isHTTPSHealthCheck(hclbService) {
 			sa.Annotate(LBSvcHealthCheckHTTPValidateCertificate, hclbService.HealthCheck.HTTP.TLS)
 		}


### PR DESCRIPTION
The idea of that pull request is that we can assign a health check for the LB with TLS enabled and another without TLS enabled. When doing this i didn't found any solution to that problem besides adding this feature to the cloud controller. 
This currently fixes the problem for us, but it might also be nice to add a list of ports for which health check to enable TLS like: "443,8443"