### PR TITLE
ci: stop logging api token

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -19,7 +19,6 @@ jobs:
           USE_NETWORKS: yes
         run: |
           export HCLOUD_TOKEN=$(./scripts/get-token.sh)
-          cat resp.json
           go test $(go list ./... | grep e2etests) -v -timeout 60m
           ./scripts/delete-token.sh $HCLOUD_TOKEN
   k3s:


### PR DESCRIPTION
Logging the (temporary) API token here is unnecessary and potentially allows attackers to deploy malicious payloads in the Hetzner Cloud project associated with this repo, until the token is deleted and the resources are cleaned up.