### PR TITLE
dockerfile: build ccm during docker build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
+FROM golang:1.18 as builder
+
+WORKDIR /hccm
+ADD . /hccm/
+RUN CGO_ENABLED=0 go build -o hcloud-cloud-controller-manager .
+
 FROM alpine:3.12
+
 RUN apk add --no-cache ca-certificates bash
-COPY hcloud-cloud-controller-manager /bin/hcloud-cloud-controller-manager
+COPY --from=builder /hccm/hcloud-cloud-controller-manager /bin/hcloud-cloud-controller-manager
+
 ENTRYPOINT ["/bin/hcloud-cloud-controller-manager"]


### PR DESCRIPTION
This way the user of the dockerfile doesn't have to figure out the flags used for building the ccm. At this point that's only to disable cgo.

But I don't know the reasoning behind the current state, perhaps you don't want to build it explicitly?