### PR TITLE
chore: update codeowner to use groups

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hetznercloud/integrations

--- a/.gitlab/CODEOWNERS
+++ b/.gitlab/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cloud/integrations

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @LKaemmerling @4ND3R50N @apricote


### PR DESCRIPTION
Update the CODEOWNERS files to use the integrations group on GitHub and our company internal GitLab. This way we do not have to keep the files up to date manually in every repository, but instead we can just update the respective groups.