### PR TITLE
feat: drop support for Kubernetes v1.23

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        k8s: [ 1.23.15, 1.24.9, 1.25.5, 1.26.0 ]
+        k8s: [ 1.24.10, 1.25.6, 1.26.1 ]
       fail-fast: false
     name: k8s ${{ matrix.k8s }}
     steps:
@@ -25,7 +25,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        k3s: [ v1.23.15+k3s1, v1.24.9+k3s1, v1.25.5+k3s1, v1.26.0+k3s1 ]
+        k3s: [ v1.24.10+k3s1, v1.25.6+k3s1, v1.26.1+k3s1 ]
       fail-fast: false
     name: k3s ${{ matrix.k3s }}
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,9 +81,9 @@ e2e:
     CCM_IMAGE_NAME: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
   parallel:
     matrix:
-      - K8S_VERSION: [ k8s-1.23.15, k8s-1.24.9, k8s-1.25.5, k8s-1.26.0 ]
+      - K8S_VERSION: [ k8s-1.24.10, k8s-1.25.6, k8s-1.26.1 ]
         USE_NETWORKS: ["yes", "no"]
-      - K8S_VERSION: [ k3s-v1.23.15+k3s1, k3s-v1.24.9+k3s1, k3s-v1.25.5+k3s1, k3s-v1.26.0+k3s1 ]
+      - K8S_VERSION: [ k3s-v1.24.10+k3s1, k3s-v1.25.6+k3s1, k3s-v1.26.1+k3s1 ]
         USE_NETWORKS: ["yes", "no"]
   before_script:
     - apk add --no-cache git make musl-dev go openssh-client

--- a/README.md
+++ b/README.md
@@ -182,21 +182,21 @@ release.
 
 ### With Networks support
 
-| Kubernetes |           k3s | Cloud Controller Manager |        Deployment File                                                                                     |
-|------------|--------------:|-------------------------:|-----------------------------------------------------------------------------------------------------------:|
-| 1.26       |  v1.26.0+k3s1 |                     main | https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm-networks.yaml |
-| 1.25       |  v1.25.5+k3s1 |                     main | https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm-networks.yaml |
-| 1.24       |  v1.24.9+k3s1 |                     main | https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm-networks.yaml |
-| 1.23       | v1.23.15+k3s1 |                     main | https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm-networks.yaml |
+| Kubernetes |           k3s | Cloud Controller Manager |                                                                                             Deployment File |
+|------------|--------------:|-------------------------:|------------------------------------------------------------------------------------------------------------:|
+| 1.26       |  v1.26.1+k3s1 |                     main |  https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm-networks.yaml |
+| 1.25       |  v1.25.6+k3s1 |                     main |  https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm-networks.yaml |
+| 1.24       | v1.24.10+k3s1 |                     main |  https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm-networks.yaml |
+| 1.23       | v1.23.15+k3s1 |                  v1.13.2 | https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/v1.13.2/ccm-networks.yaml |
 
 ### Without Networks support
 
-| Kubernetes |           k3s | Cloud Controller Manager | Deployment File                                                                                   |
-|------------|--------------:|-------------------------:|--------------------------------------------------------------------------------------------------:|
-| 1.26       |  v1.26.0+k3s1 |                     main | https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm.yaml |
-| 1.25       |  v1.25.5+k3s1 |                     main | https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm.yaml |
-| 1.24       |  v1.24.9+k3s1 |                     main | https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm.yaml |
-| 1.23       | v1.23.15+k3s1 |                     main | https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm.yaml |
+| Kubernetes |           k3s | Cloud Controller Manager |                                                                                    Deployment File |
+|------------|--------------:|-------------------------:|---------------------------------------------------------------------------------------------------:|
+| 1.26       |  v1.26.1+k3s1 |                     main |  https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm.yaml |
+| 1.25       |  v1.25.6+k3s1 |                     main |  https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm.yaml |
+| 1.24       | v1.24.10+k3s1 |                     main |  https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm.yaml |
+| 1.23       | v1.23.15+k3s1 |                  v1.13.2 | https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/v1.13.2/ccm.yaml |
 
 ## Unit tests
 


### PR DESCRIPTION
Remove Kubernetes v1.23 from CI tests and mark the latest released version in README.

This is in accordance with our Kubernetes Support Policy which states that we support the latest three releases.

We should only merge this after 2023-02-28, when v1.23 is considered EOL bei upstream.