### PR TITLE
docs(lb): reference existing lb #351

### DIFF
--- a/docs/load_balancers.md
+++ b/docs/load_balancers.md
@@ -12,7 +12,7 @@ kind: Service
 metadata:
   name: example-service
   annotations:
-   load-balancer.hetzner.cloud/location: hel1
+    load-balancer.hetzner.cloud/location: hel1
 spec:
   selector:
     app: example
@@ -31,7 +31,7 @@ A list of all available annotations can be found on
 [pkg.go.dev](https://pkg.go.dev/github.com/hetznercloud/hcloud-cloud-controller-manager/internal/annotation#Name).
 If you have the cloud controller deployed with Private Network Support,
 we attach the Load Balancer to the specific network automatically. You
-can specifiy with an annotation that the Load Balancer should use the
+can specify with an annotation that the Load Balancer should use the
 private network instead of the public network.
 
 ## Sample Service with Networks:
@@ -42,8 +42,8 @@ kind: Service
 metadata:
   name: example-service
   annotations:
-   load-balancer.hetzner.cloud/location: hel1
-   load-balancer.hetzner.cloud/use-private-ip: "true"
+    load-balancer.hetzner.cloud/location: hel1
+    load-balancer.hetzner.cloud/use-private-ip: "true"
 spec:
   selector:
     app: example
@@ -56,16 +56,41 @@ spec:
 For IPVS based plugins (kube-router, kube-proxy in ipvs mode, etc...) make sure you
 supply '**load-balancer.hetzner.cloud/disable-private-ingress: "true"**' annotation
 to your service or set "**HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS**" environment variable
-to true on hcloud-controller-manager deployment as mentioned in a paragraph below. Otherwise, network
+to true on hcloud-cloud-controller-manager deployment as mentioned in a paragraph below. Otherwise, network
 plugin installs load balancer's IP address on system's dummy interface effectively
 looping IPVS system in a cycle. In such scenario cluster nodes won't ever pass load balancer's health probes
 
 ## Cluster-wide Defaults
 
-For convenvience, you can set the following environment variables as cluster-wide defaults, so you don't have to set them on each load balancer service. If a load balancer service has the corresponding annotation set, it overrides the default.
+For convenience, you can set the following environment variables as cluster-wide defaults, so you don't have to set them on each load balancer service. If a load balancer service has the corresponding annotation set, it overrides the default.
 
 * `HCLOUD_LOAD_BALANCERS_LOCATION` (mutually exclusive with `HCLOUD_LOAD_BALANCERS_NETWORK_ZONE`)
 * `HCLOUD_LOAD_BALANCERS_NETWORK_ZONE` (mutually exclusive with `HCLOUD_LOAD_BALANCERS_LOCATION`)
 * `HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS`
 * `HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP`
 * `HCLOUD_LOAD_BALANCERS_ENABLED`
+
+## Reference existing Load Balancers
+
+If you already have a Load Balancer that you want to use in Kubernetes, for
+example if you provisioned it in Terraform, you can specify these two
+annotations:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-service
+  annotations:
+    load-balancer.hetzner.cloud/location: hel1
+    load-balancer.hetzner.cloud/name: your-existing-lb-name
+```
+
+The Load Balancer will then be adopted by the hcloud-cloud-controller-manager,
+and the services and targets are set up for your cluster.
+
+If you delete this `Service` in Kubernetes, the hcloud-cloud-controller-manager
+will delete the associated Load Balancer. If the Load Balancer is managed
+through Terraform, this causes problems. To disable this, you can enable
+deletion protection on the Load Balancer, this way hcloud-cloud-controller-manager
+will just skip deleting it when the associated `Service` is deleted.


### PR DESCRIPTION
Document how to reference an existing load balancer for use with a `Service`. I also fixed some typos and formatting issues in the file.

Related to #351.

