### PR TITLE
test(e2e): fix flake when LB health checks have not passed

### DIFF
--- a/e2etests/testing.go
+++ b/e2etests/testing.go
@@ -576,10 +576,16 @@ func WaitForHTTPAvailable(t *testing.T, ingressIP string, useHTTPS bool) {
 			return false, nil
 		}
 		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
+		switch resp.StatusCode {
+		case http.StatusOK:
+			// Success
+			return true, nil
+		case http.StatusServiceUnavailable:
+			// Health checks are still evaluating
+			return false, nil
+		default:
 			return false, fmt.Errorf("%s: got HTTP Code %d instead of 200", op, resp.StatusCode)
 		}
-		return true, nil
 	})
 	if err != nil {
 		t.Errorf("%s: not available via client.Get: %s", op, err)


### PR DESCRIPTION
The load balancers return a status code 503 if none of the targets have passed the health checks. Our test suite failed if it received anything but a 200. By also accepting a 503 and just continuing the wait we can get rid of one of the test failures.