### PR TITLE
chore: initial basic helm chart

### DIFF
--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: hcloud-cloud-controller-manager
+type: application
+version: v1.13.2

--- a/chart/templates/clusterrolebinding.yaml
+++ b/chart/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,25 +1,3 @@
-# NOTE: this release was tested against kubernetes v1.18.x
-
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cloud-controller-manager
-  namespace: kube-system
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: system:cloud-controller-manager
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: cloud-controller-manager
-    namespace: kube-system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -49,12 +27,14 @@ spec:
         # cloud controller manages should be able to run on masters
         - key: "node-role.kubernetes.io/master"
           effect: NoSchedule
+          operator: Exists
         - key: "node-role.kubernetes.io/control-plane"
           effect: NoSchedule
+          operator: Exists
         - key: "node.kubernetes.io/not-ready"
           effect: "NoExecute"
       containers:
-        - image: hetznercloud/hcloud-cloud-controller-manager:__VERSION__
+        - image: hetznercloud/hcloud-cloud-controller-manager:{{ .Chart.Version }}
           name: hcloud-cloud-controller-manager
           command:
             - "/bin/hcloud-cloud-controller-manager"

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system

--- a/deploy/ccm.yaml
+++ b/deploy/ccm.yaml
@@ -1,12 +1,12 @@
-# NOTE: this release was tested against kubernetes v1.18.x
-
 ---
+# Source: hcloud-cloud-controller-manager/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cloud-controller-manager
   namespace: kube-system
 ---
+# Source: hcloud-cloud-controller-manager/templates/clusterrolebinding.yaml
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -20,6 +20,7 @@ subjects:
     name: cloud-controller-manager
     namespace: kube-system
 ---
+# Source: hcloud-cloud-controller-manager/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -56,7 +57,7 @@ spec:
         - key: "node.kubernetes.io/not-ready"
           effect: "NoExecute"
       containers:
-        - image: hetznercloud/hcloud-cloud-controller-manager:v1.9.1
+        - image: hetznercloud/hcloud-cloud-controller-manager:v1.13.2
           name: hcloud-cloud-controller-manager
           command:
             - "/bin/hcloud-cloud-controller-manager"

--- a/scripts/generate-deployment-yamls.sh
+++ b/scripts/generate-deployment-yamls.sh
@@ -9,6 +9,9 @@ if [[ -z $VERSION ]]; then
     exit 1
 fi
 
+cat chart/Chart.yaml | sed -e "s/version: .*/version: $VERSION/" > chart/Chart.yaml.new && mv chart/Chart.yaml{.new,}
+helm template chart > deploy/ccm.yaml
+
 for x in "$TEMPLATES_DIR"/*.yaml.tmpl; do
     outdir="$(command dirname "$x")"/gen
     file="$(command basename "$x")"


### PR DESCRIPTION
chart templates created by running the following:

```
 $ tail -n+2 deploy/ccm.yaml | kubectl slice -t '{{.kind | lower}}.yaml' -o chart/templates/
```

`generate-deployment-yaml.sh` is updated to then do the previous thing in reverse. That is, it runs `helm template chart` and the contents go in deploy/ccm.yaml

As a result of this change, deploy/ccm.yaml.tmpl is no longer needed.

In follow-up commits the dev and network flavors will be generated from the new chart, and the corresponding .tmpl files will go away.