### PR TITLE
fix(ci): main branch rename

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - v*
     branches:
-      - master
+      - main
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ test:lint:
     - golangci-lint run -v
   except:
     - tags
-    - master
+    - main
   tags:
     - hc-bladerunner
 


### PR DESCRIPTION
The "default" branch for the repository was renamed to "main" at some point in the past, but these references were missed.

At the moment we do not publish the `:latest` image tag for snapshots.