### PR TITLE
ci: fix goreleaser helm chart config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,4 +46,8 @@ release:
 
 publishers:
   - name: helm-chart-repo
+    ids: # make sure that this is only executed once by filtering for *one arbitrary* artifact ID
+      - deployment-yamls
     cmd: ./scripts/publish-helm-chart.sh hcloud-cloud-controller-manager-{{ if not .IsSnapshot }}v{{ end }}{{ .Version }}.tgz
+    env:
+      - CHART_REPO_REMOTE={{ .Env.CHART_REPO_REMOTE }}


### PR DESCRIPTION
There were [two issues](https://github.com/hetznercloud/hcloud-cloud-controller-manager/actions/runs/4407161651/jobs/7720443310#step:9:54) with the goreleaser config:

- The publishing step is executed once per artifact by default, we have two artifacts (`deployment-yamls`, `hcloud-cloud-controller-manager`). By setting the id we make sure that its only executed once.
- The CHART_REPO_REMOTE variable was not available in the script. Environment variables need to be explicitly passed to downstream commands in goreleaser.
