### PR TITLE
ci: build helm repo index

### DIFF
--- a/scripts/publish-helm-chart.sh
+++ b/scripts/publish-helm-chart.sh
@@ -17,15 +17,26 @@ TMP_DIR=$(mktemp --directory hccm-chart-repo.XXXXX)
 
 git clone --depth 1 -b "${CHART_REPO_BRANCH}" "${CHART_REPO_REMOTE}" "${TMP_DIR}"
 
-cp "${CHART_FILE}" "${TMP_DIR}/"
+mkdir "${TMP_DIR}"/new-chart
+cp "${CHART_FILE}" "${TMP_DIR}/new-chart"
 
+pushd "${TMP_DIR}/new-chart"
+
+# Update index
+# We use --merge to not update any of the other existing entries in the index file,
+# this requires us to put our new chart in a separate dir that only includes the new chart.
+helm repo index --merge ../index.yaml .
+# Move chart and merged index to root dir
+mv -f -- * ..
+
+popd
 pushd "${TMP_DIR}"
 
 # Setup git-lfs
 git lfs install --local
 
 # commit & push
-git add "${CHART_FILE}"
+git add -- index.yaml "${CHART_FILE}"
 git commit -m "feat: add ${CHART_FILE}"
 git push
 


### PR DESCRIPTION
We previously relied on the helm-charts repo to re-build the index. But this has problems:

- The gh-pages pipeline is not properly started because events created by the default GITHUB_TOKEN do not trigger pipelines (in the same repo).
- Adding the chart and re-indexing happens in two commits, slightly obfuscating the chain of events
- When running `helm repo index` it updates the created timestamp of all existing entries. While I have not seen any issues yet, there might be some clients that rely on this field.