### PR TITLE
fix(ci): wrong version published when two tags point to same commit 

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -58,6 +58,8 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
+          # https://github.com/goreleaser/goreleaser/blob/3345f8c9c5b287198a29d3db228388148b788c5e/www/docs/customization/builds.md?plain=1#L416-L418
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHART_REPO_REMOTE: "https://${{ secrets.HCLOUD_BOT_TOKEN }}@github.com/hetznercloud/helm-charts"
 

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -33,7 +33,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --snapshot --rm-dist
+          args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish latest snapshot image
@@ -56,7 +56,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           # https://github.com/goreleaser/goreleaser/blob/3345f8c9c5b287198a29d3db228388148b788c5e/www/docs/customization/builds.md?plain=1#L416-L418
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}


### PR DESCRIPTION
The tags v1.14.0-rc.2 and v1.14.0 point to the same commit. Goreleaser always releases v1.14.0-rc.2 and we don't get a proper v1.14.0 release.

By specifying the release that goreleaser should handle, we can rely on Github to specify the correct tag for the current workflow.