### PR TITLE
chore: multiple improvements to the release process

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,7 +39,6 @@ dockers:
 
 release:
   ids: [""]
-  draft: true
   extra_files:
     - glob: "./deploy/ccm*.yaml"
     - glob: "./hcloud-cloud-controller-manager-*.tgz"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,7 +41,7 @@ release:
   ids: [""]
   draft: true
   extra_files:
-    - glob: "./deploy/gen/ccm*.yaml"
+    - glob: "./deploy/ccm*.yaml"
     - glob: "./hcloud-cloud-controller-manager-*.tgz"
 
 publishers:

--- a/scripts/generate-deployment-yamls.sh
+++ b/scripts/generate-deployment-yamls.sh
@@ -9,8 +9,12 @@ if [[ -z $VERSION ]]; then
     exit 1
 fi
 
-cat chart/Chart.yaml | sed -e "s/version: .*/version: $VERSION/" > chart/Chart.yaml.new && mv chart/Chart.yaml{.new,}
+# Update version
+sed -e "s/version: .*/version: $VERSION/" --in-place chart/Chart.yaml
+
+# Template the chart with pre-built values to get the legacy deployment files
 helm template chart > deploy/ccm.yaml
 helm template chart --set networking.enabled=true > deploy/ccm-networks.yaml
 
+# Package the chart for publishing
 helm package chart


### PR DESCRIPTION
### chore: fix release missing deployment files

The path for the deployment files was changed in https://github.com/hetznercloud/hcloud-cloud-controller-manager/pull/375 but not updated here. This cause the v1.14.1 release to be missing the release artifacts until I manually uploaded them.

### chore: no draft releases

In the current release process we need to "publish" the release twice, once to create the tag and trigger `goreleaser`, and then a second time because goreleaser turned the release back into a draft.

We can just skip the drafting step and let goreleaser publish directly.

### chore: simplify chart version update

Simplify the command used to update the Chart version and add some comments.