### PR TITLE
fix: many API requests from Routes controller

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,6 +5,10 @@ args:
   leader-elect: "false"
   allow-untagged-cloud: ""
 
+  # Read issue #395 to understand how changes to this value affect you.
+  # https://github.com/hetznercloud/hcloud-cloud-controller-manager/issues/395
+  route-reconciliation-period: 30s
+
 image:
   repository: hetznercloud/hcloud-cloud-controller-manager
   tag: '{{ $.Chart.Version }}'

--- a/deploy/ccm-networks.yaml
+++ b/deploy/ccm-networks.yaml
@@ -65,6 +65,7 @@ spec:
             - "--allow-untagged-cloud"
             - "--cloud-provider=hcloud"
             - "--leader-elect=false"
+            - "--route-reconciliation-period=30s"
             - "--allocate-node-cidrs=true"
             - "--cluster-cidr=10.244.0.0/16"
           env:

--- a/deploy/ccm.yaml
+++ b/deploy/ccm.yaml
@@ -64,6 +64,7 @@ spec:
             - "--allow-untagged-cloud"
             - "--cloud-provider=hcloud"
             - "--leader-elect=false"
+            - "--route-reconciliation-period=30s"
           env:
             - name: NODE_NAME
               valueFrom:


### PR DESCRIPTION
Reduce the number of API requests coming from the routes controller by reducing the reconciliation interval from 10s to 30s.

This is only a temporary fix until we can properly refactor the routes controller to only reconcile when necessary.

Related to #395