### PR TITLE
fix(routes): Only delete routes in the Cluster CIDR

### DIFF
--- a/hcloud/routes_test.go
+++ b/hcloud/routes_test.go
@@ -140,28 +140,18 @@ func TestRoutes_ListRoutes(t *testing.T) {
 func TestRoutes_DeleteRoute(t *testing.T) {
 	env := newTestEnv()
 	defer env.Teardown()
-	env.Mux.HandleFunc("/servers", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(schema.ServerListResponse{
-			Servers: []schema.Server{
-				{
-					ID:   1,
-					Name: "node15",
-					PrivateNet: []schema.ServerPrivateNet{
-						{
-							Network: 1,
-							IP:      "10.0.0.2",
-						},
-					},
-				},
-			},
-		})
-	})
 	env.Mux.HandleFunc("/networks/1", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(schema.NetworkGetResponse{
 			Network: schema.Network{
 				ID:      1,
 				Name:    "network-1",
 				IPRange: "10.0.0.0/8",
+				Routes: []schema.NetworkRoute{
+					{
+						Destination: "10.5.0.0/24",
+						Gateway:     "10.0.0.2",
+					},
+				},
 			},
 		})
 	})


### PR DESCRIPTION
This is a two-part fix for #425.

Closes #425 

More details can be found in [this comment](https://github.com/hetznercloud/hcloud-cloud-controller-manager/issues/425#issuecomment-1525776879)

## Part 1: [fix(routes): correctly handle delete for routes without server](https://github.com/hetznercloud/hcloud-cloud-controller-manager/commit/ac55e6f91d815813469fc01801cbd436c608ad9e)

We previously required that the route we were about to delete [had a valid server](https://github.com/hetznercloud/hcloud-cloud-controller-manager/blob/892c20e199e1aee64e731aa9f05e9320dfc5d1bd/hcloud/routes.go#L161-L169). This does not make sense because in most cases we delete the route precisely because the server was deleted.

## Part 2: [fix(routes): let k/cloud-provider decide which routes to delete](https://github.com/hetznercloud/hcloud-cloud-controller-manager/commit/e2ea24c8f30ae49c0ea13b263e5ecb1f6b900dbf)

We implemented a route cleanup in https://github.com/hetznercloud/hcloud-cloud-controller-manager/pull/238 that deletes all routes in the network that can not be mapped to the private IP of a node. This causes issues for users who create their own routes, e.g. to an alias IP.

We do not need to implement this ourselves, because`kubernetes/cloud-provider` already [implemented all the checks](https://github.com/kubernetes/cloud-provider/blob/22e08785c750bd4610af7198d43ecf72b688e9ed/controllers/route/route_controller.go#L220-L260) for us, with more consideration about which routes actually need to be deleted.

In particular, the ccm should only delete routes that are within the configured `--cluster-cidr` range.