### PR TITLE
chore: match renovate commits with release-please

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+
+    // Generate commits compatible with release-please changelog
+    ":semanticCommitTypeAll(deps)",
+    ":semanticCommitScopeDisabled",
+  ]
+}


### PR DESCRIPTION
release-please defines the deps type for commits, which will be put into its own [section in the changelog](https://github.com/googleapis/release-please/blob/2b56b2213c10c6a0d3265746b10b19fbfce47292/src/changelog-notes.ts#L42-L55). This commit changes the default renovate commit message to use the deps type instead.

- Before: `fix(deps): update module github.com/prometheus/client_golang to v1.15.1`
- After: `deps: update module github.com/prometheus/client_golang to v1.15.1`

This helps declutter the "Bug Fixes" section in the changelog & release notes, so actual bug fixes are easier to review for users.