### PR TITLE
ci: fix release assets not available

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,10 +6,14 @@ name: release-please
 
 jobs:
   release-please:
+    # The secret HCLOUD_BOT_TOKEN is only available on the main repo, not in forks.
+    if: github.repository == 'hetznercloud/hcloud-cloud-controller-manager'
+
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v3
         with:
+          token: ${{ secrets.HCLOUD_BOT_TOKEN }}
           release-type: go
           package-name: hcloud-cloud-controller-manager
 


### PR DESCRIPTION
The default token GH_TOKEN in workflows does not trigger new events. We rely on the "tag" event created by release-please to build our release assets.

By using a token for "hcloud-bot", the event will be properly created.

We explicitly only run the workflow job if the repository is the main repo, as otherwise this workflow will fail in forks because the secret is not available.

See also hetznercloud/cli#476