### PR TITLE
chore(ci): fix go version in goreleaser workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: "1.20"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
CI is currently [installing Go 1.2](https://github.com/hetznercloud/hcloud-cloud-controller-manager/actions/runs/4958991607/jobs/8872533527), which incidentally does not have `go mod` support 🙈 