### PR TITLE
test: use configurable domain for managed certificate

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -36,6 +36,10 @@ jobs:
         env:
           K3S_CHANNEL: ${{ matrix.k3s }}
           SCOPE: gha-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.k3s }}
+
+          # Domain must be available in the account running the tests. This domain is available in the account
+          # running the public integration tests.
+          CERT_DOMAIN: hc-integrations-test.de
         run: |
           curl -sLS https://get.k3sup.dev | sh
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -171,7 +171,11 @@ func TestServiceLoadBalancersHTTPS(t *testing.T) {
 func TestServiceLoadBalancersHTTPSWithManagedCertificate(t *testing.T) {
 	t.Parallel()
 
-	domainName := fmt.Sprintf("%d-ccm-test.hc-certs.de", rand.Int())
+	if testCluster.certDomain == "" {
+		t.Skip("Skipping because CERT_DOMAIN is not set")
+	}
+
+	domainName := fmt.Sprintf("%d-ccm-test.%s", rand.Int(), testCluster.certDomain)
 	lbTest := lbTestHelper{
 		t:         t,
 		K8sClient: testCluster.k8sClient,

--- a/tests/e2e/testing.go
+++ b/tests/e2e/testing.go
@@ -36,6 +36,7 @@ type TestCluster struct {
 	k8sClient    *kubernetes.Clientset
 	certificates []*hcloud.Certificate
 	scope        string
+	certDomain   string
 }
 
 func (tc *TestCluster) Start() error {
@@ -83,6 +84,10 @@ func (tc *TestCluster) Start() error {
 	if err != nil {
 		return fmt.Errorf("kubernetes.NewForConfig: %s", err)
 	}
+
+	// Tests using this value should skip if empty
+	// The domain specified here must be available in Hetzner DNS of the account running the tests.
+	tc.certDomain = os.Getenv("CERT_DOMAIN")
 
 	return nil
 }

--- a/tests/e2e/testing.go
+++ b/tests/e2e/testing.go
@@ -293,7 +293,7 @@ func WaitForHTTPAvailable(t *testing.T, ingressIP string, useHTTPS bool) {
 		proto = "https"
 	}
 
-	err := wait.Poll(1*time.Second, 2*time.Minute, func() (bool, error) {
+	err := wait.Poll(1*time.Second, 4*time.Minute, func() (bool, error) {
 		resp, err := client.Get(fmt.Sprintf("%s://%s", proto, ingressIP))
 		if err != nil {
 			return false, nil


### PR DESCRIPTION
While migrating this project from TTS -> TPS we switched the Hetzner
account. The new account does not have the domain `hc-certs.de`
configured. While the test case still succeeds (does not check for cert
status), we get lots of emails for the failed certificate issuance.

This commit makes the domain used in the test configurable and skips
the test in case no domain is set.

