### PR TITLE
ci: fix linting issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: latest
+          # Required: the version of golangci-lint is required and must be specified without patch version
+          version: v1.53.3
           # In general linting is quite fast with warm caches, but a fresh run might take some time.
           args: --timeout 5m
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ variables:
 
 test:lint:
   stage: test
-  image: golangci/golangci-lint:v1.52.2
+  image: golangci/golangci-lint:v1.53.3
   allow_failure: true
   script:
     - golangci-lint run -v
@@ -27,7 +27,7 @@ test:lint:
     - tags
     - main
   tags:
-    - hc-bladerunner
+    - cloud-integrations
 
 test:unit:
   stage: test
@@ -37,7 +37,7 @@ test:unit:
   script:
     - go test $(go list ./... | grep -v e2e) -v
   tags:
-    - hc-bladerunner
+    -  cloud-integrations
 
 .build:goreleaser: &build-goreleaser
   stage: build
@@ -53,7 +53,7 @@ test:unit:
       - hcloud-cloud-controller-manager
     expire_in: 1 day
   tags:
-    - hc-bladerunner
+    -  cloud-integrations
 
 build:goreleaser:snapshot:
   <<: *build-goreleaser
@@ -94,7 +94,7 @@ e2e:
   script:
     - go test $(go list ./... | grep e2e) -v -timeout 60m
   tags:
-    - hc-bladerunner-build
+    -  cloud-integrations
 
 release:image:
   stage: release:image

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -26,7 +26,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - depguard
     - errcheck
     - errname
     - exhaustive


### PR DESCRIPTION
A new version of golangci-lint updated depguard, which in turn started returning errors because it was missing a config. Previously depguard did not do anything as we never configured a list of allowed/denied imports.

In general, we already have gomodguard for linting imports.

To avoid sudden breakages of our CI in the future, I pinned the exact version of golangci-lint to the current release. Upgrading this should happen through a PR process (e.g. by renovate) so we can notice new linting failures and fix them before merging to main.