### PR TITLE
fix(helm-chart): resource namespace and name

### DIFF
--- a/chart/templates/clusterrolebinding.yaml
+++ b/chart/templates/clusterrolebinding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: cluster-admin
 subjects:
   - kind: ServiceAccount
-    name: cloud-controller-manager
-    namespace: kube-system
+    name: {{ include "hcloud-cloud-controller-manager.name" . }}
+    namespace: {{ .Release.Namespace }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,8 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: hcloud-cloud-controller-manager
-  namespace: kube-system
+  name: {{ include "hcloud-cloud-controller-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   revisionHistoryLimit: 2
@@ -14,7 +14,7 @@ spec:
       labels:
         {{- include "hcloud-cloud-controller-manager.selectorLabels" . | nindent 8 }}
     spec:
-      serviceAccountName: cloud-controller-manager
+      serviceAccountName: {{ include "hcloud-cloud-controller-manager.name" . }}
       dnsPolicy: Default
       tolerations:
         # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.

--- a/chart/templates/podmonitor.yaml
+++ b/chart/templates/podmonitor.yaml
@@ -3,7 +3,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: hcloud-cloud-controller-manager
+  name: {{ include "hcloud-cloud-controller-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   {{- tpl (toYaml $.Values.monitoring.podMonitor.spec) $ | nindent 2 }}
   selector:

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cloud-controller-manager
-  namespace: kube-system
+  name: {{ include "hcloud-cloud-controller-manager.name" . }}
+  namespace: {{ .Release.Namespace }}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -17,6 +17,7 @@ manifests:
   helm:
     releases:
       - name: hccm
+        namespace: kube-system
         chartPath: chart
         setValues:
           networking.enabled: true


### PR DESCRIPTION
This should fix the issue that you can change the release namespace with helm, but the deployment will not take care of it. 

Also this allows the user to use the nameoverwrite that was already defined inside the chart helpers.