### PR TITLE
ci: fix failure on main when pushing latest image

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -31,6 +31,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Run GoReleaser for snapshot
+        # This does not actually publish anything, but makes sure that the images can be build
         if: "!startsWith(github.ref, 'refs/tags/')"
         uses: goreleaser/goreleaser-action@v4
         with:
@@ -38,13 +39,6 @@ jobs:
           args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish latest snapshot image
-        if: "!startsWith(github.ref, 'refs/tags/')"
-        env:
-          DOCKER_USER: ${{ secrets.DOCKER_USER }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: |
-           docker push hetznercloud/hcloud-cloud-controller-manager:latest
 
       # Git is used to push helm chart to hetznercloud/helm-charts
       - name: Setup Git


### PR DESCRIPTION
Since reworking the docker build process in #417 we do not have a ":latest" image to push. The CI pipeline in main has failed since then.

Getting a "latest" image is not that easy with the current goreleaser setup. We use the goreleaser docker_manifests feature to build multi-arch images. This stage is not executed in "--snapshot" builds.

Example CI failure: https://github.com/hetznercloud/hcloud-cloud-controller-manager/actions/runs/5461797507/jobs/9940263986