### PR TITLE
feat(helm): allow to set labels and annotations for podMonitor

### DIFF
--- a/chart/templates/podmonitor.yaml
+++ b/chart/templates/podmonitor.yaml
@@ -5,6 +5,14 @@ kind: PodMonitor
 metadata:
   name: {{ include "hcloud-cloud-controller-manager.name" . }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- with $.Values.monitoring.podMonitor.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- range $key, $value := .Values.monitoring.podMonitor.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   {{- tpl (toYaml $.Values.monitoring.podMonitor.spec) $ | nindent 2 }}
   selector:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -35,11 +35,17 @@ monitoring:
     # When enabled (and metrics.enabled=true), a PodMonitor will be deployed to scrape metrics.
     # The PodMonitor [1] CRD must already exist in the target cluster.
     enabled: false
+    # PodMonitor Labels
+    labels: {}
+    #   release: kube-prometheus-stack
+    # PodMonitor Annotations
+    annotations: {}
     # PodMonitorSpec to be deployed. The "selector" field is set elsewhere and should *not* be used here.
     # https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.PodMonitorSpec
     spec:
       podMetricsEndpoints:
         - port: metrics
+    
 
 nameOverride: ~
 


### PR DESCRIPTION
This PR adds the ability to set labels and annotations to the podMonitor. Setting the label is usually necessary for the podMonitor to be picked up by the Prometheus Operator (https://github.com/prometheus-operator/prometheus-operator/issues/3636#issuecomment-796688902). Setting an annotation helps to defer the deployment of the custom resource if e.g. deploying with ArgoCD (https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types).