### PR TITLE
chore: fix skaffold debug

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,6 +5,7 @@ metadata:
 build:
   artifacts:
     - image: hetznercloud/hcloud-cloud-controller-manager
+      runtimeType: go
       docker:
         dockerfile: hack/Dockerfile
         cacheFrom:


### PR DESCRIPTION
Skaffold debug failed because it could not figure out the runtime. Explicitly setting it to go makes it work.