### PR TITLE
ci: fix helm chart publishing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,12 +20,6 @@ builds:
     ldflags:
       - "-s -w -X github.com/hetznercloud/hcloud-cloud-controller-manager/hcloud.providerVersion={{ if not .IsSnapshot }}v{{ end }}{{ .Version }}"
 
-archives:
-  - id: deployment-yamls
-    builds: [""]
-    name_template: "{{ .ProjectName }}_{{ .Version }}_deployment_yamls"
-    wrap_in_directory: true
-
 dockers:
   - build_flag_templates: [--platform=linux/amd64]
     dockerfile: Dockerfile
@@ -59,8 +53,12 @@ release:
 
 publishers:
   - name: helm-chart-repo
-    ids: # make sure that this is only executed once by filtering for *one arbitrary* artifact ID
-      - deployment-yamls
+
+    # make sure that this is only executed once. There are no separate ids per binary built,
+    # we filter for no actual ID and then run the publisher for the checksum.
+    ids: [""]
+    checksum: true
+
     cmd: ./scripts/publish-helm-chart.sh hcloud-cloud-controller-manager-{{ if not .IsSnapshot }}v{{ end }}{{ .Version }}.tgz
     env:
       - CHART_REPO_REMOTE={{ .Env.CHART_REPO_REMOTE }}


### PR DESCRIPTION
The helm chart was not published since 1.15.0. The script was not even called, because a change between 1.15.0-rc.0 & 1.15.0 caused the archive step to not be executed anymore.

As we never did anything with the archive anyway, I have removed it now.

Instead we ensure the "execute once" requirement for the chart publish by depending on the checksum output.

Closes #460 