### PR TITLE
fix(deploy): manifests have wrong namespace "default"

### DIFF
--- a/deploy/ccm-networks.yaml
+++ b/deploy/ccm-networks.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cloud-controller-manager
+  name: hcloud-cloud-controller-manager
   namespace: kube-system
 ---
 # Source: hcloud-cloud-controller-manager/templates/clusterrolebinding.yaml
@@ -17,7 +17,7 @@ roleRef:
   name: cluster-admin
 subjects:
   - kind: ServiceAccount
-    name: cloud-controller-manager
+    name: hcloud-cloud-controller-manager
     namespace: kube-system
 ---
 # Source: hcloud-cloud-controller-manager/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       labels:
         app: hcloud-cloud-controller-manager
     spec:
-      serviceAccountName: cloud-controller-manager
+      serviceAccountName: hcloud-cloud-controller-manager
       dnsPolicy: Default
       tolerations:
         # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.
@@ -81,8 +81,8 @@ spec:
             - name: HCLOUD_NETWORK
               valueFrom:
                 secretKeyRef:
-                  name: hcloud
                   key: network
+                  name: hcloud
           image: hetznercloud/hcloud-cloud-controller-manager:v1.17.0 # x-release-please-version
           ports:
             - name: metrics

--- a/deploy/ccm.yaml
+++ b/deploy/ccm.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cloud-controller-manager
+  name: hcloud-cloud-controller-manager
   namespace: kube-system
 ---
 # Source: hcloud-cloud-controller-manager/templates/clusterrolebinding.yaml
@@ -17,7 +17,7 @@ roleRef:
   name: cluster-admin
 subjects:
   - kind: ServiceAccount
-    name: cloud-controller-manager
+    name: hcloud-cloud-controller-manager
     namespace: kube-system
 ---
 # Source: hcloud-cloud-controller-manager/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       labels:
         app: hcloud-cloud-controller-manager
     spec:
-      serviceAccountName: cloud-controller-manager
+      serviceAccountName: hcloud-cloud-controller-manager
       dnsPolicy: Default
       tolerations:
         # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.

--- a/scripts/generate-deployment-yamls.sh
+++ b/scripts/generate-deployment-yamls.sh
@@ -13,7 +13,7 @@ fi
 sed -e "s/version: .*/version: $VERSION/" --in-place chart/Chart.yaml
 
 # Template the chart with pre-built values to get the legacy deployment files
-helm_template='helm template chart --set selectorLabels."app\.kubernetes\.io/name"=null,selectorLabels."app\.kubernetes\.io/instance"=null,selectorLabels.app=hcloud-cloud-controller-manager'
+helm_template='helm template chart --namespace kube-system --set selectorLabels."app\.kubernetes\.io/name"=null,selectorLabels."app\.kubernetes\.io/instance"=null,selectorLabels.app=hcloud-cloud-controller-manager'
 eval $helm_template > deploy/ccm.yaml
 eval $helm_template --set networking.enabled=true > deploy/ccm-networks.yaml
 


### PR DESCRIPTION
The command to generate the manifests was missing a namespace. This caused the manifests to have resources in namespace "default" which is not intended and a breaking change.

Fixes #475 