### PR TITLE
fix(deploy): make last resource name configurable

### DIFF
--- a/chart/templates/clusterrolebinding.yaml
+++ b/chart/templates/clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: system:cloud-controller-manager
+  name: "system:{{ include "hcloud-cloud-controller-manager.name" . }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/ccm-networks.yaml
+++ b/deploy/ccm-networks.yaml
@@ -10,7 +10,7 @@ metadata:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: system:cloud-controller-manager
+  name: "system:hcloud-cloud-controller-manager"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/ccm.yaml
+++ b/deploy/ccm.yaml
@@ -10,7 +10,7 @@ metadata:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: system:cloud-controller-manager
+  name: "system:hcloud-cloud-controller-manager"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
This is the last resource whose name was not configurable through the helm name override.