### PR TITLE
ci: check deployment manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,24 @@ jobs:
           export PATH=$(go env GOPATH)/bin:$PATH
           go get golang.org/x/tools/cmd/goimports
           diff -u <(echo -n) <(goimports -d .)
+
+  deploy-manifests:
+    name: Check deployment manifests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: yokawasa/action-setup-kube-tools@v0.9.3
+        with:
+          setup-tools: |
+            helm
+          helm: v3.11.2
+
+      - uses: actions/checkout@v3
+      - name: Generate manifests from helm chart
+        run: scripts/update-deployment-yamls.sh
+
+      - name: Check for diff
+        run: git diff --exit-code -- deploy/
+
+      - name: Show warning
+        if: ${{ failure() }}
+        run: echo "::error title=Deployment Manifests outdated::Please run scripts/update-deployment-yamls.sh and commit the changes to deploy/"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@
 before:
   hooks:
     - go mod tidy
-    - ./scripts/generate-deployment-yamls.sh {{ if not .IsSnapshot }}v{{ end }}{{ .Version }}
+    - ./scripts/release-generate-deployment-yamls.sh {{ if not .IsSnapshot }}v{{ end }}{{ .Version }}
 
 builds:
   - id: hcloud-cloud-controller-manager

--- a/scripts/release-generate-deployment-yamls.sh
+++ b/scripts/release-generate-deployment-yamls.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -ueo pipefail
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+: "${TEMPLATES_DIR:=./deploy}"
+
+VERSION="$1"
+
+if [[ -z $VERSION ]]; then
+    echo "Usage: $0 <version>"
+    exit 1
+fi
+
+# Update version
+sed -e "s/version: .*/version: $VERSION/" --in-place chart/Chart.yaml
+
+"$SCRIPT_DIR"/update-deployment-yamls.sh
+
+# Package the chart for publishing
+helm package chart

--- a/scripts/update-deployment-yamls.sh
+++ b/scripts/update-deployment-yamls.sh
@@ -1,21 +1,7 @@
 #!/usr/bin/env bash
-
-: "${TEMPLATES_DIR:=./deploy}"
-
-VERSION="$1"
-
-if [[ -z $VERSION ]]; then
-    echo "Usage: $0 <version>"
-    exit 1
-fi
-
-# Update version
-sed -e "s/version: .*/version: $VERSION/" --in-place chart/Chart.yaml
+set -ueo pipefail
 
 # Template the chart with pre-built values to get the legacy deployment files
 helm_template='helm template chart --namespace kube-system --set selectorLabels."app\.kubernetes\.io/name"=null,selectorLabels."app\.kubernetes\.io/instance"=null,selectorLabels.app=hcloud-cloud-controller-manager'
 eval $helm_template > deploy/ccm.yaml
 eval $helm_template --set networking.enabled=true > deploy/ccm-networks.yaml
-
-# Package the chart for publishing
-helm package chart


### PR DESCRIPTION
We had some issues where the committed files in deploy/ did not match the files included with releases. This job makes sure that the files in deploy/ always match the current output from running "helm chart template".

[Example pipeline that demonstrates the output](https://github.com/hetznercloud/hcloud-cloud-controller-manager/actions/runs/5597677338)

Related to #476.