### PR TITLE
ci: only run ci.yml once per PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 ---
 name: Run tests
-on: [ push, pull_request ]
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
 jobs:
   test:
     name: Unit Tests


### PR DESCRIPTION
The current rules will create all the jobs in ci.yml twice for PRs. Once with the pull_request event, and then once again because the commit was pushed. This is annoying and wastes CI resources.

This fixes it by only running for PRs and pushes to main (instead of all branches). The same config is already used for the e2e tests.