### PR TITLE
fix(deploy): do not bind webhook port 10260

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -9,6 +9,11 @@ args:
   # https://github.com/hetznercloud/hcloud-cloud-controller-manager/issues/395
   route-reconciliation-period: 30s
 
+  # We do not use the webhooks feature and there is no need to bind a port that is unused.
+  # https://github.com/kubernetes/kubernetes/issues/120043
+  # https://github.com/hetznercloud/hcloud-cloud-controller-manager/issues/492
+  webhook-secure-port: "0"
+
 # hccm environment variables
 env:
   # The following two variables should *not* be set here:

--- a/deploy/ccm-networks.yaml
+++ b/deploy/ccm-networks.yaml
@@ -66,6 +66,7 @@ spec:
             - "--cloud-provider=hcloud"
             - "--leader-elect=false"
             - "--route-reconciliation-period=30s"
+            - "--webhook-secure-port=0"
             - "--allocate-node-cidrs=true"
             - "--cluster-cidr=10.244.0.0/16"
           env:

--- a/deploy/ccm.yaml
+++ b/deploy/ccm.yaml
@@ -65,6 +65,7 @@ spec:
             - "--cloud-provider=hcloud"
             - "--leader-elect=false"
             - "--route-reconciliation-period=30s"
+            - "--webhook-secure-port=0"
           env:
             - name: HCLOUD_TOKEN
               valueFrom:


### PR DESCRIPTION
Our dependency `k/cloud-provider` started binding this port in version 0.27.0 to serve webhooks from. We are not using the webhook feature and the port bind is causing conflicts for deployments that use the native networking feature (which enables `hostNetwork`).

See also:
- https://github.com/hetznercloud/hcloud-cloud-controller-manager/issues/492
- https://github.com/kubernetes/kubernetes/issues/120043