### PR TITLE
ci: fix flake in dev/e2e env where subnet is not available

### DIFF
--- a/hack/dev-up.sh
+++ b/hack/dev-up.sh
@@ -77,7 +77,7 @@ if [[ -n "${DEBUG:-}" ]]; then set -x; fi
       if [[ -z "${ip:-}" ]]; then
         # Wait for SSH key
         until hcloud ssh-key describe $scope_name >/dev/null 2>&1; do sleep 1; done
-        until hcloud network describe $scope_name >/dev/null 2>&1; do sleep 1; done
+        until hcloud network describe $scope_name 2>&1 | grep $subnet_cidr >/dev/null; do sleep 1; done
 
         createcmd="hcloud server create --image $image_name --label $label --location $location --name $server_name --ssh-key=$scope_name --type $instance_type --network $scope_name"
         for key in $ssh_keys; do


### PR DESCRIPTION
The e2e tests fail regularly with error message:

    hcloud: network 3334615 has no free IP available or is in a different network zone (invalid_input)

As far as I can tell, this happens because the network does not yet have an available subnet when the server is created. With this change, we will wait until the network has the subnet (by grepping for the subnet cidr) before creating the server.

Related to https://github.com/hetznercloud/csi-driver/pull/492