### PR TITLE
chore(dev-env): fix issue with k3s flags on agents

### DIFF
--- a/hack/dev-up.sh
+++ b/hack/dev-up.sh
@@ -34,8 +34,8 @@ if [[ -n "${DEBUG:-}" ]]; then set -x; fi
   scope_name=hccm-${scope}
   label="managedby=hack,scope=$scope_name"
   ssh_private_key="$SCRIPT_DIR/.ssh-$scope"
-  k3s_opts=${K3S_OPTS:-"--kubelet-arg cloud-provider=external --disable=traefik --disable=servicelb --flannel-backend=none --disable=local-storage"}
-  k3s_server_opts=${K3S_SERVER_OPTS:-"--disable-cloud-controller --cluster-cidr ${cluster_cidr}"}
+  k3s_opts=${K3S_OPTS:-"--kubelet-arg cloud-provider=external"}
+  k3s_server_opts=${K3S_SERVER_OPTS:-"--disable-cloud-controller --disable=traefik --disable=servicelb --flannel-backend=none --disable=local-storage --cluster-cidr ${cluster_cidr}"}
 
   echo -n "$HCLOUD_TOKEN" > "$SCRIPT_DIR/.token-$scope"
 


### PR DESCRIPTION
Any agents that were added to the dev env cluster (INSTANCES>1) would fail to initialize because they were being passed server-specific flags.

This commit moves these flags to the server only.