### PR TITLE
feat(chart): add daemonset and node selector

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -50,8 +50,11 @@ If you've already deployed hccm using the `helm install` command above, you can 
 helm upgrade hccm hcloud/hcloud-cloud-controller-manager -n kube-system --set monitoring.podMonitor.enabled=true
 ```
 
-### Multiple replicas
+### Multiple replicas / DaemonSet
 
-If you want to use multiple replicas you can change `replicaCount` inside the helm values. 
+You can choose between different deployment options. By default the chart will deploy a single replica as a Deployment.
 
+If you want to change the replica count you can adjust the value `replicaCount` inside the helm values.
 If you have more than 1 replica leader election will be turned on automatically.
+
+If you want to deploy hccm as a DaemonSet you can set `kind` to `DaemonSet` inside the values. 

--- a/chart/README.md
+++ b/chart/README.md
@@ -58,3 +58,4 @@ If you want to change the replica count you can adjust the value `replicaCount` 
 If you have more than 1 replica leader election will be turned on automatically.
 
 If you want to deploy hccm as a DaemonSet you can set `kind` to `DaemonSet` inside the values. 
+To adjust on which nodes the DaemonSet should be deployed you can use the `nodeSelector` and `additionalTolerations` values.

--- a/chart/templates/daemonset.yaml
+++ b/chart/templates/daemonset.yaml
@@ -1,11 +1,10 @@
-{{- if eq $.Values.kind "Deployment" }}
+{{- if eq $.Values.kind "DaemonSet" }}
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: {{ include "hcloud-cloud-controller-manager.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/chart/templates/daemonset.yaml
+++ b/chart/templates/daemonset.yaml
@@ -38,6 +38,11 @@ spec:
         {{- if gt (len .Values.additionalTolerations) 0 }}
         {{ toYaml .Values.additionalTolerations | nindent 8 }}
         {{- end }}
+      
+      {{- if gt (len .Values.nodeSelector) 0 }}
+      nodeSelector: 
+        {{ toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
 
       {{- if $.Values.networking.enabled }}
       hostNetwork: true

--- a/chart/templates/daemonset.yaml
+++ b/chart/templates/daemonset.yaml
@@ -60,9 +60,6 @@ spec:
             - "--allocate-node-cidrs=true"
             - "--cluster-cidr={{ $.Values.networking.clusterCIDR }}"
             {{- end }}
-            {{- if (eq (int $.Values.replicaCount) 1) }}
-            - "--leader-elect=false"
-            {{- end }}
           env:
             {{- range $key, $value := $.Values.env }}
             - name: {{ $key }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -39,6 +39,11 @@ spec:
         {{- if gt (len .Values.additionalTolerations) 0 }}
         {{ toYaml .Values.additionalTolerations | nindent 8 }}
         {{- end }}
+      
+      {{- if gt (len .Values.nodeSelector) 0 }}
+      nodeSelector: 
+        {{ toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
 
       {{- if $.Values.networking.enabled }}
       hostNetwork: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -13,6 +13,10 @@ args:
   # https://github.com/hetznercloud/hcloud-cloud-controller-manager/issues/492
   webhook-secure-port: "0"
 
+# Change deployment kind from "Deployment" to "DaemonSet"
+kind: Deployment
+
+# change replicaCount (only used when kind is "Deployment")
 replicaCount: 1
 
 # hccm environment variables

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -82,3 +82,6 @@ selectorLabels:
   app.kubernetes.io/instance: '{{ $.Release.Name }}'
 
 additionalTolerations: []
+
+nodeSelector: {}
+  # node-role.kubernetes.io/control-plane: ""


### PR DESCRIPTION
This adds the ability to run hccm as a `DaemonSet` like other cloud controller managers. 
There are also nodeSelectors as a new value to set where the DaemonSet (and deployment) should run. 

The default deployment kind of `Deployment` with 1 replica is not touched. 

The new configuration options are documented in the README file.