### PR TITLE
chore(dev): fix multiple issues in dev environment scripts

### DIFF
--- a/hack/dev-down.sh
+++ b/hack/dev-down.sh
@@ -9,9 +9,9 @@ label="managedby=hack"
 
 if [[ "${ALL:-}" == "" ]]; then
   label="$label,scope=$scope_name"
-  rm -f $SCRIPT_DIR/.ssh-$scope $SCRIPT_DIR/.kubeconfig-$scope
+  rm -f $SCRIPT_DIR/.ssh-$scope* $SCRIPT_DIR/.kubeconfig-$scope $SCRIPT_DIR/.token-$scope $SCRIPT_DIR/.reg-pf*
 else
-  rm -f $SCRIPT_DIR/.ssh* $SCRIPT_DIR/.kubeconfig*
+  rm -f $SCRIPT_DIR/.ssh* $SCRIPT_DIR/.kubeconfig* $SCRIPT_DIR/.token-* $SCRIPT_DIR/.reg-pf*
 fi
 
 for instance in $(hcloud server list -o noheader -o columns=id -l $label); do

--- a/hack/dev-up.sh
+++ b/hack/dev-up.sh
@@ -129,7 +129,7 @@ if [[ -n "${DEBUG:-}" ]]; then set -x; fi
     # Deploy private registry.
     ( trap error ERR
       if ! helm status -n kube-system registry >/dev/null 2>&1; then
-        helm install registry docker-registry \
+        helm upgrade -install registry docker-registry \
           --repo=https://helm.twun.io \
           -n kube-system \
           --version 2.2.2 \
@@ -142,7 +142,7 @@ if [[ -n "${DEBUG:-}" ]]; then set -x; fi
     # Install Cilium.
     ( trap error ERR
       if ! helm status -n kube-system cilium >/dev/null 2>&1; then
-        helm install cilium cilium --repo https://helm.cilium.io/ -n kube-system --version 1.13.1 \
+        helm upgrade -install cilium cilium --repo https://helm.cilium.io/ -n kube-system --version 1.13.1 \
           --set tunnel=disabled \
           --set ipv4NativeRoutingCIDR=$cluster_cidr \
           --set ipam.mode=kubernetes


### PR DESCRIPTION
**[chore(dev): clean all files related to dev env in hack/dev-down.sh](https://github.com/hetznercloud/hcloud-cloud-controller-manager/commit/0577061d03cd4005bb80a276666af9557e153343)**

The left-over files sometimes caused issues when the environment was re-deployed.

**[chore(dev): fix issue when helm install fails](https://github.com/hetznercloud/hcloud-cloud-controller-manager/commit/b1c4d3a69af7a3a23242daedd7acd87b653e1759)**

While `helm status` checks for a successful install, `helm install` will fail when a pre-existing failed install exists. By using `helm upgrade -install` the install will be retried if it previously failed.

