### PR TITLE
refactor: use build tags to differentiate test suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Run tests
         run: |
           go vet ./...
-          go test $(go list ./... | grep -v e2e)
+          go test ./...
 
   lint:
     name: Lint

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -49,4 +49,4 @@ jobs:
           skaffold build --tag="e2e-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
           tag=$(skaffold build --tag="e2e-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}" --quiet --output="{{ (index .Builds 0).Tag }}")
           skaffold deploy --images=hetznercloud/hcloud-cloud-controller-manager=$tag
-          go test ./tests/e2e -v -timeout 60m
+          go test ./... -tags e2e -v -timeout 60m

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ test:unit:
   variables:
     NODE_NAME: "test"
   script:
-    - go test $(go list ./... | grep -v e2e) -v
+    - go test ./... -v
 
 .build:goreleaser: &build-goreleaser
   stage: build
@@ -86,7 +86,7 @@ e2e:
     - docker login $CI_REGISTRY --username=$CI_REGISTRY_USER --password=$CI_REGISTRY_PASSWORD
     - docker pull $CCM_IMAGE_NAME
   script:
-    - go test $(go list ./... | grep e2e) -v -timeout 60m
+    - go test ./... -tags e2e -v -timeout 60m
 
 release:image:
   stage: release:image

--- a/README.md
+++ b/README.md
@@ -193,13 +193,16 @@ not fix bugs related only to an unsupported version.
 To run unit tests locally, execute
 
 ```sh
-go test $(go list ./... | grep -v e2e) -v
+go test ./...
 ```
 
-Check that your go version is up to date, tests might fail if it is not.
+Check that your go version is up-to-date, tests might fail if it is not.
 
-If in doubt, check which go version the `test:unit` section in `.gitlab-ci.yml`
-has set in the `image: golang:$VERSION`.
+If in doubt, check which go version is installed in the [ci.yaml](.github/workflows/ci.yaml) GitHub Actions Workflow:
+
+```yaml
+go-version: "1.21"
+```
 
 ## E2E Tests
 
@@ -234,10 +237,10 @@ export KEEP_SERVER_ON_FAILURE=yes # Keep the test server after a test failure.
 2. Run the tests
 
 ```bash
-go test $(go list ./... | grep e2e) -v -timeout 60m
+go test ./... -tags e2e -v -timeout 60m
 ```
 
-The tests will now run and cleanup themselves afterwards. Sometimes it might happen that you need to clean up the
+The tests will now run and cleanup themselves afterward. Sometimes it might happen that you need to clean up the
 project manually via the [Hetzner Cloud Console](https://console.hetzner.cloud) or
 the [hcloud-cli](https://github.com/hetznercloud/cli) .
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package e2e
 
 import (

--- a/tests/e2e/testing.go
+++ b/tests/e2e/testing.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package e2e
 
 import (


### PR DESCRIPTION
Add the build tag `e2e` to differentiate the long running e2e tests from shorter unit tests. This way we do not need to keep track of which files have which tests and the default "go test ./..." only executes the fast unit tests.