### PR TITLE
feat: remove unused variable NODE_NAME

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,8 +32,6 @@ test:lint:
 test:unit:
   stage: test
   image: golang:1.21
-  variables:
-    NODE_NAME: "test"
   script:
     - go test ./... -v
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -29,10 +29,6 @@ env:
       secretKeyRef:
         name: hcloud
         key: token
-  NODE_NAME:
-    valueFrom:
-      fieldRef:
-        fieldPath: spec.nodeName
 
 image:
   repository: hetznercloud/hcloud-cloud-controller-manager

--- a/deploy/ccm-networks.yaml
+++ b/deploy/ccm-networks.yaml
@@ -75,10 +75,6 @@ spec:
                 secretKeyRef:
                   key: token
                   name: hcloud
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             - name: HCLOUD_NETWORK
               valueFrom:
                 secretKeyRef:

--- a/deploy/ccm.yaml
+++ b/deploy/ccm.yaml
@@ -72,10 +72,6 @@ spec:
                 secretKeyRef:
                   key: token
                   name: hcloud
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
           image: hetznercloud/hcloud-cloud-controller-manager:v1.18.0 # x-release-please-version
           ports:
             - name: metrics

--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -51,7 +51,6 @@ const (
 	hcloudLoadBalancersDisableIPv6           = "HCLOUD_LOAD_BALANCERS_DISABLE_IPV6"
 	hcloudMetricsEnabledENVVar               = "HCLOUD_METRICS_ENABLED"
 	hcloudMetricsAddress                     = ":8233"
-	nodeNameENVVar                           = "NODE_NAME"
 	providerName                             = "hcloud"
 )
 
@@ -75,10 +74,6 @@ func newCloud(_ io.Reader) (cloudprovider.Interface, error) {
 	}
 	if len(token) != 64 {
 		return nil, fmt.Errorf("entered token is invalid (must be exactly 64 characters long)")
-	}
-	nodeName := os.Getenv(nodeNameENVVar)
-	if nodeName == "" {
-		return nil, fmt.Errorf("environment variable %q is required", nodeNameENVVar)
 	}
 
 	opts := []hcloud.ClientOption{

--- a/hcloud/cloud_test.go
+++ b/hcloud/cloud_test.go
@@ -68,7 +68,6 @@ func TestNewCloud(t *testing.T) {
 	resetEnv := Setenv(t,
 		"HCLOUD_ENDPOINT", env.Server.URL,
 		"HCLOUD_TOKEN", "jr5g7ZHpPptyhJzZyHw2Pqu4g9gTqDvEceYpngPf79jN_NOT_VALID_dzhepnahq",
-		"NODE_NAME", "test",
 		"HCLOUD_METRICS_ENABLED", "false",
 	)
 	defer resetEnv()
@@ -104,7 +103,6 @@ func TestNewCloudConnectionNotPossible(t *testing.T) {
 	resetEnv := Setenv(t,
 		"HCLOUD_ENDPOINT", "http://127.0.0.1:4711/v1",
 		"HCLOUD_TOKEN", "jr5g7ZHpPptyhJzZyHw2Pqu4g9gTqDvEceYpngPf79jN_NOT_VALID_dzhepnahq",
-		"NODE_NAME", "test",
 		"HCLOUD_METRICS_ENABLED", "false",
 	)
 	defer resetEnv()
@@ -121,7 +119,6 @@ func TestNewCloudInvalidToken(t *testing.T) {
 	resetEnv := Setenv(t,
 		"HCLOUD_ENDPOINT", env.Server.URL,
 		"HCLOUD_TOKEN", "jr5g7ZHpPptyhJzZyHw2Pqu4g9gTqDvEceYpngPf79jN_NOT_VALID_dzhepnahq",
-		"NODE_NAME", "test",
 		"HCLOUD_METRICS_ENABLED", "false",
 	)
 	defer resetEnv()
@@ -149,7 +146,6 @@ func TestCloud(t *testing.T) {
 	resetEnv := Setenv(t,
 		"HCLOUD_ENDPOINT", env.Server.URL,
 		"HCLOUD_TOKEN", "jr5g7ZHpPptyhJzZyHw2Pqu4g9gTqDvEceYpngPf79jN_NOT_VALID_dzhepnahq",
-		"NODE_NAME", "test",
 		"HCLOUD_METRICS_ENABLED", "false",
 	)
 	defer resetEnv()


### PR DESCRIPTION
This variable is unused. It does not matter where HCCM is running, as long as it can talk to the Kubernetes & Hetzner Cloud APIs.