### PR TITLE
refactor: only enable routes if network name or id is configured

### DIFF
--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -155,7 +155,7 @@ func (c *cloud) Clusters() (cloudprovider.Clusters, bool) {
 }
 
 func (c *cloud) Routes() (cloudprovider.Routes, bool) {
-	if c.networkID == 0 || !c.cfg.Route.Enabled {
+	if !c.cfg.Route.Enabled {
 		// If no network is configured, disable the routes controller
 		return nil, false
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -134,9 +134,12 @@ func Read() (HCCMConfiguration, error) {
 		errs = append(errs, err)
 	}
 
-	cfg.Route.Enabled, err = getEnvBool(hcloudNetworkRoutesEnabled, true)
-	if err != nil {
-		errs = append(errs, err)
+	// Enabling Routes only makes sense when a Network is configured, otherwise there is no network to add the routes to.
+	if cfg.Network.NameOrID != "" {
+		cfg.Route.Enabled, err = getEnvBool(hcloudNetworkRoutesEnabled, true)
+		if err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -23,7 +23,6 @@ func TestRead(t *testing.T) {
 				Metrics:      MetricsConfiguration{Enabled: true, Address: ":8233"},
 				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4},
 				LoadBalancer: LoadBalancerConfiguration{Enabled: true},
-				Route:        RouteConfiguration{Enabled: true},
 			},
 			wantErr: nil,
 		},
@@ -62,7 +61,6 @@ func TestRead(t *testing.T) {
 				Metrics:      MetricsConfiguration{Enabled: true, Address: ":8233"},
 				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4},
 				LoadBalancer: LoadBalancerConfiguration{Enabled: true},
-				Route:        RouteConfiguration{Enabled: true},
 			},
 			wantErr: nil,
 		},
@@ -75,7 +73,6 @@ func TestRead(t *testing.T) {
 				Metrics:      MetricsConfiguration{Enabled: true, Address: ":8233"},
 				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv6},
 				LoadBalancer: LoadBalancerConfiguration{Enabled: true},
-				Route:        RouteConfiguration{Enabled: true},
 			},
 			wantErr: nil,
 		},
@@ -100,13 +97,17 @@ func TestRead(t *testing.T) {
 		{
 			name: "route",
 			env: []string{
+				"HCLOUD_NETWORK", "foobar",
 				"HCLOUD_NETWORK_ROUTES_ENABLED", "false",
 			},
 			want: HCCMConfiguration{
 				Metrics:      MetricsConfiguration{Enabled: true, Address: ":8233"},
 				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4},
 				LoadBalancer: LoadBalancerConfiguration{Enabled: true},
-				Route:        RouteConfiguration{Enabled: false},
+				Network: NetworkConfiguration{
+					NameOrID: "foobar",
+				},
+				Route: RouteConfiguration{Enabled: false},
 			},
 			wantErr: nil,
 		},
@@ -131,13 +132,15 @@ func TestRead(t *testing.T) {
 					UsePrivateIP:          true,
 					DisableIPv6:           true,
 				},
-				Route: RouteConfiguration{Enabled: true},
 			},
 			wantErr: nil,
 		},
 		{
 			name: "error parsing bool values",
 			env: []string{
+				// Required to parse HCLOUD_NETWORK_ROUTES_ENABLED
+				"HCLOUD_NETWORK", "foobar",
+
 				"HCLOUD_DEBUG", "foo",
 				"HCLOUD_METRICS_ENABLED", "bar",
 				"HCLOUD_LOAD_BALANCERS_ENABLED", "nej",


### PR DESCRIPTION
Clean up the config logic to be reuasble in other parts of the code.