### PR TITLE
ci: improve lint and test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 ---
-name: Run tests
+name: CI
 
 on:
   push:
@@ -11,45 +11,29 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version: "1.21"
-      - uses: actions/checkout@v4
-      - name: Run tests
-        run: |
-          go vet ./...
-          go test ./...
+
+      - run: go test -v ./...
 
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version: "1.21"
-      - uses: actions/checkout@v4
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+          cache: false
+      
+      - uses: golangci/golangci-lint-action@v3
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version
-          version: v1.54.2
+          version: v1.55.1 # renovate: datasource=github-releases depName=golangci/golangci-lint
+          
           # In general linting is quite fast with warm caches, but a fresh run might take some time.
           args: --timeout 5m
-
-  imports:
-    name: Check Imports
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: "1.21"
-      - uses: actions/checkout@v4
-      - name: Check imports
-        shell: bash
-        run: |
-          export PATH=$(go env GOPATH)/bin:$PATH
-          go get golang.org/x/tools/cmd/goimports
-          diff -u <(echo -n) <(goimports -d .)
 
   deploy-manifests:
     name: Check deployment manifests


### PR DESCRIPTION
- Remove CI job already covered by golangci-lint
- Add a renovate regex comment to renovate the golangci-lint version
- Cleanup/Simplify