### PR TITLE
chore: use semver with helm chart

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: hcloud-cloud-controller-manager
 type: application
-version: v1.18.0 # x-release-please-version
+version: 1.18.0 # x-release-please-version

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -32,7 +32,7 @@ env:
 
 image:
   repository: hetznercloud/hcloud-cloud-controller-manager
-  tag: '{{ $.Chart.Version }}'
+  tag: 'v{{ $.Chart.Version }}'
 
 monitoring:
   # When enabled, the hccm Pod will serve metrics on port :8233


### PR DESCRIPTION
This commit updates the chart version of hcloud-cloud-controller-manager We only need to update the version in Chart.yaml because `goreleaser` already strips the `v` from {{ .Version }}

To patch the extra `v` with image tag, I updated the template to use `tag: 'v{{ $.Chart.Version }}'`



Ref: https://goreleaser.com/customization/release/#github 
Above, the name template looks something like this. 

`name_template: "{{.ProjectName}}-v{{.Version}} {{.Env.USER}}"`

So, IMHO, we don't need to make any change in `.goreleaser.yaml`
For testing and Ref: 
I created a snapshot release locally using `goreleaser release --snapshot` and the diff updates the chart version and image tag as per the requirement described in the issue. 

<details><summary> Attached Screenshot </summary>
<p>

![image](https://github.com/hetznercloud/hcloud-cloud-controller-manager/assets/81210977/1c6ad108-5cee-4486-9e1f-ee9dcc702254)


</p>
</details> 

Fixes #529 