### PR TITLE
fix(deployment): revert #560: remove dns-policy

### DIFF
--- a/chart/templates/daemonset.yaml
+++ b/chart/templates/daemonset.yaml
@@ -15,6 +15,7 @@ spec:
         {{- include "hcloud-cloud-controller-manager.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "hcloud-cloud-controller-manager.name" . }}
+      dnsPolicy: Default
       tolerations:
         # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.
         - key: "node.cloudprovider.kubernetes.io/uninitialized"

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         {{- include "hcloud-cloud-controller-manager.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "hcloud-cloud-controller-manager.name" . }}
+      dnsPolicy: Default
       tolerations:
         # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.
         - key: "node.cloudprovider.kubernetes.io/uninitialized"

--- a/deploy/ccm-networks.yaml
+++ b/deploy/ccm-networks.yaml
@@ -38,6 +38,7 @@ spec:
         app: hcloud-cloud-controller-manager
     spec:
       serviceAccountName: hcloud-cloud-controller-manager
+      dnsPolicy: Default
       tolerations:
         # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.
         - key: "node.cloudprovider.kubernetes.io/uninitialized"

--- a/deploy/ccm.yaml
+++ b/deploy/ccm.yaml
@@ -38,6 +38,7 @@ spec:
         app: hcloud-cloud-controller-manager
     spec:
       serviceAccountName: hcloud-cloud-controller-manager
+      dnsPolicy: Default
       tolerations:
         # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.
         - key: "node.cloudprovider.kubernetes.io/uninitialized"


### PR DESCRIPTION
This reverts commit 2c8378647923d3758bef63bc96dd83c5cb422f85 / #560.

The commit caused a regression where clusters not using the host network were unable to bootstrap successfully:

- CoreDNS did not start because the Node was still tainted as uninitalized
- HCCM could not initialize the Node because it failed to resolve the DNS entry for "api.hetzner.cloud".