### PR TITLE
chore: prepare 1.19.0 release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,6 +17,12 @@ jobs:
           release-type: go
           package-name: hcloud-cloud-controller-manager
 
+          # We published a 1.19.0-rc.0 to verify the build process and provide
+          # people with a test version. We would like to have the full changelog
+          # since the last proper release v1.18.0 (this sha).
+          last-release-sha: 9e2926c6f0c4194d359b831975c17759e3033caf
+          release-as: 1.19.0
+
           # These files reference the version in the OCI image tag.
           extra-files: |
             deploy/ccm.yaml


### PR DESCRIPTION
Instruct `release-please` to skip the pre-release tag `1.19.0-rc.0` when building the changelog for the next release, and force it to create a new release called `1.19.0` next.