### PR TITLE
feat: add ability to use node ip as LB target

### DIFF
--- a/hcloud/instances.go
+++ b/hcloud/instances.go
@@ -80,6 +80,7 @@ func (i *instances) lookupServer(
 			return nil, errMissingRobotClient
 		}
 		server, err := getRobotServerByID(i.robotClient, int(serverID), node)
+
 		if err != nil {
 			return nil, fmt.Errorf("failed to get robot server \"%d\": %w", serverID, err)
 		}

--- a/hcloud/instances_util.go
+++ b/hcloud/instances_util.go
@@ -19,6 +19,7 @@ package hcloud
 import (
 	"context"
 	"fmt"
+	"k8s.io/klog/v2"
 	"strings"
 
 	hrobotmodels "github.com/syself/hrobot-go/models"
@@ -91,6 +92,7 @@ func getRobotServerByID(c robot.Client, id int, node *corev1.Node) (*hrobotmodel
 
 	// check whether name matches - otherwise this server does not belong to the respective node anymore
 	if server.Name != node.Name {
+		klog.Warningf("%s: server %d has name %q, but node %q has name %q. if you want node to be matched with node in Hetzner Robot you should rename it.", op, id, server.Name, node.Name, node.Name)
 		return nil, nil
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ const (
 	hcloudLoadBalancersNetworkZone           = "HCLOUD_LOAD_BALANCERS_NETWORK_ZONE"
 	hcloudLoadBalancersDisablePrivateIngress = "HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS"
 	hcloudLoadBalancersUsePrivateIP          = "HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP"
+	hcloudLoadBalancersUseNodeIP             = "HCLOUD_LOAD_BALANCERS_USE_NODE_IP"
 	hcloudLoadBalancersDisableIPv6           = "HCLOUD_LOAD_BALANCERS_DISABLE_IPV6"
 
 	hcloudMetricsEnabled = "HCLOUD_METRICS_ENABLED"
@@ -74,6 +75,7 @@ type LoadBalancerConfiguration struct {
 	NetworkZone           string
 	DisablePrivateIngress bool
 	UsePrivateIP          bool
+	UseNodeIP             bool
 	DisableIPv6           bool
 }
 
@@ -154,6 +156,10 @@ func Read() (HCCMConfiguration, error) {
 		errs = append(errs, err)
 	}
 	cfg.LoadBalancer.UsePrivateIP, err = getEnvBool(hcloudLoadBalancersUsePrivateIP, false)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	cfg.LoadBalancer.UseNodeIP, err = getEnvBool(hcloudLoadBalancersUseNodeIP, false)
 	if err != nil {
 		errs = append(errs, err)
 	}

--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -570,8 +570,10 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 		// Set of all K8S server IDs currently assigned as nodes to this
 		// cluster.
 		k8sNodeIDsHCloud = make(map[int64]bool)
-		k8sNodeIDsRobot  = make(map[int]bool)
+		k8sNodeIDsRobot  = make(map[int]*corev1.Node)
 		k8sNodeNames     = make(map[int64]string)
+
+		internalRobotIPsToNode = make(map[string]*corev1.Node)
 
 		robotIPsToIDs = make(map[string]int)
 		robotIDToIPv4 = make(map[int]string)
@@ -607,7 +609,10 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 		if isCloudServer {
 			k8sNodeIDsHCloud[id] = true
 		} else {
-			k8sNodeIDsRobot[int(id)] = true
+			if l.Cfg.LoadBalancer.UseNodeIP {
+				internalRobotIPsToNode[node.Status.Addresses[0].Address] = node
+			}
+			k8sNodeIDsRobot[int(id)] = node
 		}
 		k8sNodeNames[id] = node.Name
 	}
@@ -634,6 +639,8 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 	// not assigned as nodes to the K8S Load Balancer.
 	for _, target := range lb.Targets {
 		if target.Type == hcloud.LoadBalancerTargetTypeServer {
+			// We have to check if corresponding node exists at our cluster, if it does, we don't need to delete
+			// the target
 			id := target.Server.Server.ID
 			recreate := target.UsePrivateIP != usePrivateIP
 			hclbTargetIDs[id] = k8sNodeIDsHCloud[id] && !recreate
@@ -660,7 +667,15 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 		if target.Type == hcloud.LoadBalancerTargetTypeIP {
 			ip := target.IP.IP
 			id, foundServer := robotIPsToIDs[ip]
-			hclbTargetIPs[ip] = foundServer && k8sNodeIDsRobot[id]
+			_, exists := k8sNodeIDsRobot[id]
+			hclbTargetIPs[ip] = foundServer && exists
+
+			if l.Cfg.LoadBalancer.UseNodeIP {
+				_, exists = internalRobotIPsToNode[ip]
+
+				hclbTargetIPs[ip] = exists
+			}
+
 			if hclbTargetIPs[ip] {
 				continue
 			}
@@ -728,8 +743,12 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 	if l.Cfg.Robot.Enabled {
 		// Assign the dedicated servers which are currently assigned as nodes
 		// to the K8S Load Balancer as IP targets to the HC Load Balancer.
-		for id := range k8sNodeIDsRobot {
+		for id, node := range k8sNodeIDsRobot {
 			ip := robotIDToIPv4[id]
+
+			if l.Cfg.LoadBalancer.UseNodeIP {
+				ip = node.Status.Addresses[0].Address
+			}
 
 			// Don't assign the node again if it is already assigned to the HC load
 			// balancer.


### PR DESCRIPTION
(sorry for any possible mistakes in this PR, I'm not really familiar with Go)
In this PR I added the ability to use node ip as the target for the Hetzner LB. The motivation behind this is that current Robot implementation only adds public IPs from the Robot to the LB, and someone might have cluster setup like this, which uses internal IP from the vswitch.

```
k get node -o wide
NAME    STATUS   ROLES           AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                KERNEL-VERSION   CONTAINER-RUNTIME
node1   Ready    control-plane   5h51m   v1.28.3   10.0.1.3      <none>        Talos (v1.6.0-beta.1)   6.1.65-talos     containerd://1.7.10
```

which just doesn't work with following implementation. I also added warning for when the name in the Robot and k8s don't match. It's opt-in and you have to specify `HCLOUD_LOAD_BALANCERS_USE_NODE_IP` to use that.

I ran the controller like 

```bash
 ROBOT_ENABLED=true \
HCLOUD_TOKEN= ROBOT_PASSWORD=ROBOT_USER="" \
KUBECONFIG=$HOME/.kube-old/config  \
HCLOUD_NETWORK=1047143 \
HCLOUD_NETWORK_ROUTES_ENABLED=false \
HCLOUD_NETWORK_DISABLE_ATTACHED_CHECK=true \
HCLOUD_LOAD_BALANCERS_USE_NODE_IP=true \
go run . --allow-untagged-cloud  --cloud-provider=hcloud --route-reconciliation-period=30s --webhook-secure-port=0 --leader-elect=false --kubeconfig=$HOME/.kube-old/config

```
and it worked like a charm for me. Result:

<img width="1567" alt="Pasted_Image_16_12_23__02_45" src="https://github.com/hetznercloud/hcloud-cloud-controller-manager/assets/17164985/26861daf-dd7a-4989-ae65-f5e6528f184b">

Since you're specifying a network I have to also use flags like `HCLOUD_NETWORK_ROUTES_ENABLED` and `HCLOUD_NETWORK_DISABLE_ATTACHED_CHECK`.

Would love to add test for it, but I think it's going to add a lot of complexities testing this along with a vswitch.