### PR TITLE
feat: emit Kubernetes events for error conditions

### DIFF
--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -24,6 +24,9 @@ import (
 	"strings"
 
 	hrobot "github.com/syself/hrobot-go"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 
@@ -46,6 +49,7 @@ type cloud struct {
 	client      *hcloud.Client
 	robotClient robot.Client
 	cfg         config.HCCMConfiguration
+	recorder    record.EventRecorder
 	networkID   int64
 }
 
@@ -122,11 +126,15 @@ func newCloud(_ io.Reader) (cloudprovider.Interface, error) {
 
 	klog.Infof("Hetzner Cloud k8s cloud controller %s started\n", providerVersion)
 
+	eventBroadcaster := record.NewBroadcaster()
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "hcloud-cloud-controller-manager"})
+
 	return &cloud{
 		client:      client,
 		robotClient: robotClient,
 		cfg:         cfg,
 		networkID:   networkID,
+		recorder:    recorder,
 	}, nil
 }
 
@@ -139,7 +147,7 @@ func (c *cloud) Instances() (cloudprovider.Instances, bool) {
 }
 
 func (c *cloud) InstancesV2() (cloudprovider.InstancesV2, bool) {
-	return newInstances(c.client, c.robotClient, c.cfg.Instance.AddressFamily, c.networkID), true
+	return newInstances(c.client, c.robotClient, c.recorder, c.cfg.Instance.AddressFamily, c.networkID), true
 }
 
 func (c *cloud) Zones() (cloudprovider.Zones, bool) {

--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -168,6 +168,7 @@ func (c *cloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 		NetworkClient: &c.client.Network,
 		NetworkID:     c.networkID,
 		Cfg:           c.cfg,
+		Recorder:      c.recorder,
 	}
 
 	return newLoadBalancers(lbOps, c.cfg.LoadBalancer.DisablePrivateIngress, c.cfg.LoadBalancer.DisableIPv6), true

--- a/hcloud/cloud_test.go
+++ b/hcloud/cloud_test.go
@@ -27,6 +27,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	hrobot "github.com/syself/hrobot-go"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 
 	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/testsupport"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
@@ -38,6 +41,7 @@ type testEnv struct {
 	Mux         *http.ServeMux
 	Client      *hcloud.Client
 	RobotClient hrobot.RobotClient
+	Recorder    record.EventRecorder
 }
 
 func (env *testEnv) Teardown() {
@@ -46,6 +50,7 @@ func (env *testEnv) Teardown() {
 	env.Mux = nil
 	env.Client = nil
 	env.RobotClient = nil
+	env.Recorder = nil
 }
 
 func newTestEnv() testEnv {
@@ -59,11 +64,13 @@ func newTestEnv() testEnv {
 	)
 	robotClient := hrobot.NewBasicAuthClient("", "")
 	robotClient.SetBaseURL(server.URL + "/robot")
+	recorder := record.NewBroadcaster().NewRecorder(scheme.Scheme, corev1.EventSource{Component: "hcloud-cloud-controller-manager"})
 	return testEnv{
 		Server:      server,
 		Mux:         mux,
 		Client:      client,
 		RobotClient: robotClient,
+		Recorder:    recorder,
 	}
 }
 

--- a/hcloud/instances_test.go
+++ b/hcloud/instances_test.go
@@ -89,7 +89,7 @@ func TestInstances_InstanceExists(t *testing.T) {
 		})
 	})
 
-	instances := newInstances(env.Client, env.RobotClient, config.AddressFamilyIPv4, 0)
+	instances := newInstances(env.Client, env.RobotClient, env.Recorder, config.AddressFamilyIPv4, 0)
 
 	tests := []struct {
 		name     string
@@ -209,7 +209,7 @@ func TestInstances_InstanceShutdown(t *testing.T) {
 		})
 	})
 
-	instances := newInstances(env.Client, env.RobotClient, config.AddressFamilyIPv4, 0)
+	instances := newInstances(env.Client, env.RobotClient, env.Recorder, config.AddressFamilyIPv4, 0)
 	env.Mux.HandleFunc("/robot/server/3", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(hrobotmodels.ServerResponse{
 			Server: hrobotmodels.Server{
@@ -343,7 +343,7 @@ func TestInstances_InstanceMetadata(t *testing.T) {
 		})
 	})
 
-	instances := newInstances(env.Client, env.RobotClient, config.AddressFamilyIPv4, 0)
+	instances := newInstances(env.Client, env.RobotClient, env.Recorder, config.AddressFamilyIPv4, 0)
 
 	metadata, err := instances.InstanceMetadata(context.TODO(), &corev1.Node{
 		Spec: corev1.NodeSpec{ProviderID: "hcloud://1"},
@@ -384,7 +384,7 @@ func TestInstances_InstanceMetadataRobotServer(t *testing.T) {
 		})
 	})
 
-	instances := newInstances(env.Client, env.RobotClient, config.AddressFamilyIPv4, 0)
+	instances := newInstances(env.Client, env.RobotClient, env.Recorder, config.AddressFamilyIPv4, 0)
 
 	metadata, err := instances.InstanceMetadata(context.TODO(), &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{

--- a/hcloud/routes.go
+++ b/hcloud/routes.go
@@ -103,7 +103,7 @@ func (r *routes) CreateRoute(ctx context.Context, clusterName string, nameHint s
 
 		privNet, ok = findServerPrivateNetByID(srv, r.network.ID)
 		if !ok {
-			return fmt.Errorf("%s: server %v: network with id %d not attached to this server ", op, route.TargetNode, r.network.ID)
+			return fmt.Errorf("%s: server %v: network with id %d not attached to this server", op, route.TargetNode, r.network.ID)
 		}
 	}
 	ip := privNet.IP

--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -701,6 +701,7 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 		}
 
 		if numberOfTargets >= lb.LoadBalancerType.MaxTargets {
+			// TODO: Event
 			klog.InfoS("cannot add server target because max number of targets have been reached", "op", op, "service", svc.ObjectMeta.Name, "targetName", k8sNodeNames[id])
 			continue
 		}
@@ -714,6 +715,8 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 		if err != nil {
 			if hcloud.IsError(err, hcloud.ErrorCodeResourceLimitExceeded) {
 				klog.InfoS("resource limit exceeded", "err", err.Error(), "op", op, "service", svc.ObjectMeta.Name, "targetName", k8sNodeNames[id])
+				// TODO: Event
+				// TODO: continue?
 				return false, nil
 			}
 			return changed, fmt.Errorf("%s: target %s: %w", op, k8sNodeNames[id], err)
@@ -737,11 +740,13 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 				continue
 			}
 			if ip == "" {
+				// TODO: Event
 				klog.InfoS("k8s node found but no corresponding server in robot", "id", id)
 				continue
 			}
 
 			if numberOfTargets >= lb.LoadBalancerType.MaxTargets {
+				// TODO: Event
 				klog.InfoS("cannot add ip target because max number of targets have been reached", "op", op, "service", svc.ObjectMeta.Name, "targetName", k8sNodeNames[int64(id)])
 				continue
 			}
@@ -754,6 +759,8 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 			if err != nil {
 				if hcloud.IsError(err, hcloud.ErrorCodeResourceLimitExceeded) {
 					klog.InfoS("resource limit exceeded", "err", err.Error(), "op", op, "service", svc.ObjectMeta.Name, "targetName", k8sNodeNames[int64(id)])
+					// TODO: Event
+					// TODO: continue?
 					return false, nil
 				}
 				return changed, fmt.Errorf("%s: target %s: %w", op, k8sNodeNames[int64(id)], err)

--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -791,6 +791,7 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 	return changed, nil
 }
 
+//nolint:unparam ops might get set to different values in the future
 func (l *LoadBalancerOps) emitMaxTargetsReachedError(node *corev1.Node, svc *corev1.Service, op string) {
 	l.Recorder.Eventf(node, corev1.EventTypeWarning, "MaxTargetsReached",
 		"Node could not be added to Load Balancer for service %s because the max number of targets has been reached",

--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -791,7 +791,7 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 	return changed, nil
 }
 
-//nolint:unparam ops might get set to different values in the future
+//nolint:unparam // op might get set to different values in the future
 func (l *LoadBalancerOps) emitMaxTargetsReachedError(node *corev1.Node, svc *corev1.Service, op string) {
 	l.Recorder.Eventf(node, corev1.EventTypeWarning, "MaxTargetsReached",
 		"Node could not be added to Load Balancer for service %s because the max number of targets has been reached",

--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -732,7 +732,7 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 		a, _, err := l.LBClient.AddServerTarget(ctx, lb, opts)
 		if err != nil {
 			if hcloud.IsError(err, hcloud.ErrorCodeResourceLimitExceeded) {
-				klog.InfoS("resource limit exceeded", "err", err.Error(), "op", op, "service", svc.ObjectMeta.Name, "targetName", node)
+				l.emitMaxTargetsReachedError(node, svc, op)
 				// Continue loop so that error is emitted for each node
 				continue
 			}

--- a/internal/hcops/testing.go
+++ b/internal/hcops/testing.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	hrobotmodels "github.com/syself/hrobot-go/models"
+	"k8s.io/client-go/tools/record"
 
 	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/mocks"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
@@ -49,6 +50,7 @@ func NewLoadBalancerOpsFixture(t *testing.T) *LoadBalancerOpsFixture {
 		ActionClient:  fx.ActionClient,
 		NetworkClient: fx.NetworkClient,
 		RobotClient:   fx.RobotClient,
+		Recorder:      &record.FakeRecorder{},
 	}
 
 	return fx


### PR DESCRIPTION
`k/cloud-provider` emits Events for most errors we return. In some conditions we previously hid the errors from `k/cloud-provider` for various reasons and only logged a warning. This is hard to discover for users. With this change, we now also emit Kubernetes Events for these cases.