### PR TITLE
Fix managed certificate load balancer service

### DIFF
--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -1016,7 +1016,7 @@ func (b *hclbServiceOptsBuilder) extract() {
 
 	b.do(func() error {
 		certtyp, ok := annotation.LBSvcHTTPCertificateType.StringFromService(b.Service)
-		if ok && certtyp == string(hcloud.CertificateTypeManaged) {
+		if ok && certtyp != string(hcloud.CertificateTypeManaged) {
 			// Continue with managed certificates below
 			return nil
 		}


### PR DESCRIPTION
Looks like this is the reason why managed certificate is never attached to lb https service.