### PR TITLE
feat: read HCLOUD_TOKEN from file

### DIFF
--- a/chart/templates/daemonset.yaml
+++ b/chart/templates/daemonset.yaml
@@ -13,6 +13,9 @@ spec:
     metadata:
       labels:
         {{- include "hcloud-cloud-controller-manager.selectorLabels" . | nindent 8 }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
     spec:
       serviceAccountName: {{ include "hcloud-cloud-controller-manager.name" . }}
       dnsPolicy: Default

--- a/chart/templates/daemonset.yaml
+++ b/chart/templates/daemonset.yaml
@@ -13,9 +13,13 @@ spec:
     metadata:
       labels:
         {{- include "hcloud-cloud-controller-manager.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
         {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
+      {{- if .Values.podAnnotations }}
       annotations:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "hcloud-cloud-controller-manager.name" . }}
       dnsPolicy: Default

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
     metadata:
       labels:
         {{- include "hcloud-cloud-controller-manager.selectorLabels" . | nindent 8 }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
     spec:
       serviceAccountName: {{ include "hcloud-cloud-controller-manager.name" . }}
       dnsPolicy: Default

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -14,9 +14,13 @@ spec:
     metadata:
       labels:
         {{- include "hcloud-cloud-controller-manager.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
         {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
+      {{- if .Values.podAnnotations }}
       annotations:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "hcloud-cloud-controller-manager.name" . }}
       dnsPolicy: Default

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -31,11 +31,13 @@ env:
 
   # You can also use a file to provide secrets to the hcloud-cloud-controller-manager.
   # This is currently possible for HCLOUD_TOKEN, ROBOT_USER, and ROBOT_PASSWORD.
-  # The value of the env var (e.g. HCLOUD_TOKEN) must start with "file:" to indicate that the value is a file path.
+  # Use the env var appended with _FILE (e.g. HCLOUD_TOKEN_FILE) and set the value to the file path that should be read
   # The file must be provided externally (e.g. via secret injection).
   # Example:
-  # HCLOUD_TOKEN:
-  #   value: "file:/etc/hetzner/token"
+  # HCLOUD_TOKEN_FILE:
+  #   value: "/etc/hetzner/token"
+  # to disable reading the token from the secret you have to disable the original env var:
+  # HCLOUD_TOKEN: null
 
   HCLOUD_TOKEN:
     valueFrom:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -29,6 +29,14 @@ env:
   # HCLOUD_NETWORK - see networking.enabled
   # ROBOT_ENABLED - see robot.enabled
 
+  # You can also use a file to provide secrets to the hcloud-cloud-controller-manager.
+  # This is currently possible for HCLOUD_TOKEN, ROBOT_USER, and ROBOT_PASSWORD.
+  # The value of the env var (e.g. HCLOUD_TOKEN) must start with "file:" to indicate that the value is a file path.
+  # The file must be provided externally (e.g. via secret injection).
+  # Example:
+  # HCLOUD_TOKEN:
+  #   value: "file:/etc/hetzner/token"
+
   HCLOUD_TOKEN:
     valueFrom:
       secretKeyRef:
@@ -103,3 +111,7 @@ nodeSelector: {}
 robot:
   # Set to true to enable support for Robot (Dedicated) servers.
   enabled: false
+
+podLabels: {}
+
+podAnnotations: {}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,7 +102,7 @@ func readFromEnvOrFile(envVar string) (string, error) {
 	if strings.HasPrefix(value, "file:") {
 		valueBytes, err := os.ReadFile(strings.TrimPrefix(value, "file:"))
 		if err != nil {
-			return "", errors.New("failed to read " + envVar + " from file: " + err.Error())
+			return "", fmt.Errorf("failed to read %s from file: %w", envVar, err) 
 		}
 		return strings.TrimSpace(string(valueBytes)), nil
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,7 +98,7 @@ type HCCMConfiguration struct {
 }
 
 // read values from environment variables or from file set via _FILE env var
-// values set directly via env var take precedence over values set via file
+// values set directly via env var take precedence over values set via file.
 func readFromEnvOrFile(envVar string) (string, error) {
 	// check if the value is set directly via env (e.g. HCLOUD_TOKEN)
 	value, ok := os.LookupEnv(envVar)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -49,6 +49,25 @@ func TestRead(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "secrets from file",
+			env: []string{
+				"HCLOUD_TOKEN", "file:/etc/hetzner/token",
+				"ROBOT_USER", "file:/etc/hetzner/user",
+				"ROBOT_PASSWORD", "file:/etc/hetzner/password",
+			},
+			want: HCCMConfiguration{
+				HCloudClient: HCloudClientConfiguration{Token: ""},
+				Robot:        RobotConfiguration{User: "", Password: "", CacheTimeout: 0},
+				Metrics:      MetricsConfiguration{Enabled: false},
+				Instance:     InstanceConfiguration{},
+				LoadBalancer: LoadBalancerConfiguration{Enabled: false},
+				Route:        RouteConfiguration{Enabled: false},
+			},
+			wantErr: errors.New(`failed to read HCLOUD_TOKEN from file: open /etc/hetzner/token: no such file or directory
+failed to read ROBOT_USER from file: open /etc/hetzner/user: no such file or directory
+failed to read ROBOT_PASSWORD from file: open /etc/hetzner/password: no such file or directory`),
+		},
+		{
 			name: "client",
 			env: []string{
 				"HCLOUD_TOKEN", "jr5g7ZHpPptyhJzZyHw2Pqu4g9gTqDvEceYpngPf79jN_NOT_VALID_dzhepnahq",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -52,9 +52,9 @@ func TestRead(t *testing.T) {
 		{
 			name: "secrets from file",
 			env: []string{
-				"HCLOUD_TOKEN", "file:hetzner-token",
-				"ROBOT_USER", "file:hetzner-user",
-				"ROBOT_PASSWORD", "file:hetzner-password",
+				"HCLOUD_TOKEN_FILE", "/tmp/hetzner-token",
+				"ROBOT_USER_FILE", "/tmp/hetzner-user",
+				"ROBOT_PASSWORD_FILE", "/tmp/hetzner-password",
 			},
 			files: map[string]string{
 				"hetzner-token":    "jr5g7ZHpPptyhJzZyHw2Pqu4g9gTqDvEceYpngPf79jN_NOT_VALID_dzhepnahq",
@@ -80,10 +80,11 @@ func TestRead(t *testing.T) {
 		{
 			name: "secrets from unknown file",
 			env: []string{
-				"HCLOUD_TOKEN", "file:/etc/hetzner/token",
-				"ROBOT_USER", "file:/etc/hetzner/user",
-				"ROBOT_PASSWORD", "file:/etc/hetzner/password",
+				"HCLOUD_TOKEN_FILE", "/tmp/hetzner-token",
+				"ROBOT_USER_FILE", "/tmp/hetzner-user",
+				"ROBOT_PASSWORD_FILE", "/tmp/hetzner-password",
 			},
+			files: map[string]string{}, // don't create files
 			want: HCCMConfiguration{
 				HCloudClient: HCloudClientConfiguration{Token: ""},
 				Robot:        RobotConfiguration{User: "", Password: "", CacheTimeout: 0},
@@ -92,9 +93,9 @@ func TestRead(t *testing.T) {
 				LoadBalancer: LoadBalancerConfiguration{Enabled: false},
 				Route:        RouteConfiguration{Enabled: false},
 			},
-			wantErr: errors.New(`failed to read HCLOUD_TOKEN from file: open /etc/hetzner/token: no such file or directory
-failed to read ROBOT_USER from file: open /etc/hetzner/user: no such file or directory
-failed to read ROBOT_PASSWORD from file: open /etc/hetzner/password: no such file or directory`),
+			wantErr: errors.New(`failed to read HCLOUD_TOKEN_FILE: open /tmp/hetzner-token: no such file or directory
+failed to read ROBOT_USER_FILE: open /tmp/hetzner-user: no such file or directory
+failed to read ROBOT_PASSWORD_FILE: open /tmp/hetzner-password: no such file or directory`),
 		},
 		{
 			name: "client",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -256,7 +256,7 @@ failed to parse ROBOT_RATE_LIMIT_WAIT_TIME: time: unknown unit "fortnights" in d
 		t.Run(tt.name, func(t *testing.T) {
 			resetEnv := testsupport.Setenv(t, tt.env...)
 			defer resetEnv()
-			resetFiles := testsupport.Setfiles(t, tt.files)
+			resetFiles := testsupport.SetFiles(t, tt.files)
 			defer resetFiles()
 
 			got, err := Read()

--- a/internal/testsupport/files.go
+++ b/internal/testsupport/files.go
@@ -7,7 +7,7 @@ import (
 
 // SetFiles can be used to temporarily create files on the local file system.
 // It returns a function that will clean up all files it created.
-func Setfiles(t *testing.T, files map[string]string) func() {
+func SetFiles(t *testing.T, files map[string]string) func() {
 	for file, content := range files {
 		filepath := os.TempDir() + "/" + file
 

--- a/internal/testsupport/files.go
+++ b/internal/testsupport/files.go
@@ -5,24 +5,28 @@ import (
 	"testing"
 )
 
+// SetFiles can be used to temporarily create files on the local file system.
+// It returns a function that will clean up all files it created.
 func Setfiles(t *testing.T, files map[string]string) func() {
 	for file, content := range files {
+		filepath := os.TempDir() + "/" + file
+
 		// check if file exists
-		_, err := os.Stat(file)
+		_, err := os.Stat(filepath)
 		if err == nil {
-			t.Fatalf("Trying to set file %s, but it already exists. Please choose another filepath for the test.", file)
+			t.Fatalf("Trying to set file %s, but it already exists. Please choose another filepath for the test.", filepath)
 		}
 
 		// create file
-		f, err := os.Create(file)
+		f, err := os.Create(filepath)
 		if err != nil {
-			t.Fatalf("Failed to create file %s: %v", file, err)
+			t.Fatalf("Failed to create file %s: %v", filepath, err)
 		}
 
 		// write content to file
 		_, err = f.WriteString(content)
 		if err != nil {
-			t.Fatalf("Failed to write to file %s: %v", file, err)
+			t.Fatalf("Failed to write to file %s: %v", filepath, err)
 		}
 
 		// close file
@@ -31,9 +35,10 @@ func Setfiles(t *testing.T, files map[string]string) func() {
 
 	return func() {
 		for file := range files {
-			err := os.Remove(file)
+			filepath := os.TempDir() + "/" + file
+			err := os.Remove(filepath)
 			if err != nil {
-				t.Fatalf("Failed to remove file %s: %v", file, err)
+				t.Fatalf("Failed to remove file %s: %v", filepath, err)
 			}
 		}
 	}

--- a/internal/testsupport/files.go
+++ b/internal/testsupport/files.go
@@ -1,0 +1,40 @@
+package testsupport
+
+import (
+	"os"
+	"testing"
+)
+
+func Setfiles(t *testing.T, files map[string]string) func() {
+	for file, content := range files {
+		// check if file exists
+		_, err := os.Stat(file)
+		if err == nil {
+			t.Fatalf("Trying to set file %s, but it already exists. Please choose another filepath for the test.", file)
+		}
+
+		// create file
+		f, err := os.Create(file)
+		if err != nil {
+			t.Fatalf("Failed to create file %s: %v", file, err)
+		}
+
+		// write content to file
+		_, err = f.WriteString(content)
+		if err != nil {
+			t.Fatalf("Failed to write to file %s: %v", file, err)
+		}
+
+		// close file
+		f.Close()
+	}
+
+	return func() {
+		for file := range files {
+			err := os.Remove(file)
+			if err != nil {
+				t.Fatalf("Failed to remove file %s: %v", file, err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This allows the `HCLOUD_TOKEN` (and `ROBOT_USER` and `ROBOT_PASSWORD`) to be read from a file. This can be useful if the token is injected using secret injection (e.g. with the vault agent injector).

I tested the changes on my dev cluster. I cannot test the robot account changes, because I only use hcloud. But because they use the same function inside the code I think its working too :). If someone is interested in using this with the vault agent injector, I used the following helm values:

```yaml
image:
  repository: <custom-image-because-changes-are-not-released>
  tag: <custom-image-because-changes-are-not-released>
podAnnotations:
  vault.hashicorp.com/agent-inject: "true"
  vault.hashicorp.com/log-format: json
  vault.hashicorp.com/role: <your-vault-role-name>
  vault.hashicorp.com/secret-volume-path-token: /vault/secrets
  vault.hashicorp.com/agent-inject-file-token: token
  vault.hashicorp.com/agent-inject-secret-token: <your-vault-mount>/data/<your-vault-path>
  vault.hashicorp.com/agent-inject-template-token: |
    {{ with secret "<your-vault-mount>/data/<your-vault-path>" -}}
     {{ .Data.data.token }}
    {{- end }}
env:
  HCLOUD_TOKEN_FILE:
    value: "/vault/secrets/token"
  HCLOUD_TOKEN: null # must be set because helm results in using value and valueFrom and that results in an error
```

This change is inspired from [external-dns cloudflare provider](https://github.com/kubernetes-sigs/external-dns/blob/master/provider/cloudflare/cloudflare.go#L171). I requested the same change for the [csi-driver](https://github.com/hetznercloud/csi-driver/pull/617) to keep consistency in reading HCLOUD_TOKEN from file.

Closes #595 