### PR TITLE
ci: setup go version using go.mod file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: go.mod
 
       - run: go test -v -race -coverprofile=coverage.txt ./...
 
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: go.mod
 
       - uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: go.mod
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -31,10 +31,12 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - uses: hetznercloud/setup-hcloud@v1
+
       - uses: hetznercloud/tps-action@main
         with:
           token: ${{ secrets.HCLOUD_TOKEN  }}
-      - uses: hetznercloud/setup-hcloud@v1
+
       - uses: yokawasa/action-setup-kube-tools@v0.11.1
         with:
           setup-tools: |
@@ -139,10 +141,12 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - uses: hetznercloud/setup-hcloud@v1
+
       - uses: hetznercloud/tps-action@main
         with:
           token: ${{ secrets.HCLOUD_TOKEN  }}
-      - uses: hetznercloud/setup-hcloud@v1
+
       - uses: yokawasa/action-setup-kube-tools@v0.11.1
         with:
           setup-tools: |

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -25,11 +25,12 @@ jobs:
       CERT_DOMAIN: hc-integrations-test.de
 
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
-      - uses: actions/checkout@master
       - uses: hetznercloud/tps-action@main
         with:
           token: ${{ secrets.HCLOUD_TOKEN  }}
@@ -132,11 +133,12 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
-      - uses: actions/checkout@master
       - uses: hetznercloud/tps-action@main
         with:
           token: ${{ secrets.HCLOUD_TOKEN  }}

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -27,7 +27,8 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: go.mod
+
       - uses: actions/checkout@master
       - uses: hetznercloud/tps-action@main
         with:
@@ -133,7 +134,8 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: go.mod
+
       - uses: actions/checkout@master
       - uses: hetznercloud/tps-action@main
         with:


### PR DESCRIPTION
Use the `go.mod` file to determine the version of go to run in CI.