### PR TITLE
ci: update helm and skaffold for e2e tests

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -43,9 +43,9 @@ jobs:
             helm
             kubectl
             skaffold
-          helm: v3.11.2
+          helm: v3.15.1
           kubectl: v1.29.0
-          skaffold: v2.3.0
+          skaffold: v2.12.0
       - name: Install k3sup
         run: |
           curl -sLS https://get.k3sup.dev | sh
@@ -153,9 +153,9 @@ jobs:
             helm
             kubectl
             skaffold
-          helm: v3.11.2
+          helm: v3.15.1
           kubectl: v1.29.0
-          skaffold: v2.3.0
+          skaffold: v2.12.0
       - name: Install k3sup
         run: |
           curl -sLS https://get.k3sup.dev | sh


### PR DESCRIPTION
Update e2e test tools, except kubectl, to the latest version.