### PR TITLE
ci: prevent interpreter discovery to fail across distribution release

### DIFF
--- a/hack/robot-e2e/ansible.cfg
+++ b/hack/robot-e2e/ansible.cfg
@@ -2,6 +2,7 @@
 inventory = ${PWD}/inventory.yml
 host_key_checking = False
 stdout_callback = community.general.yaml
+interpreter_python = /usr/bin/python3
 
 [ssh_connection]
 pipelining = True


### PR DESCRIPTION
The interpreter discovery will set the python path to e.g. /usr/bin/python3.11 on ubuntu 24.04, but after reinstalling and rebooting the system to an older version e.g. ubuntu 24.04 => ubuntu 22.04, the previously discovered path will be invalid.

This ensures we use a non versioned path to python3.

![image](https://github.com/hetznercloud/hcloud-cloud-controller-manager/assets/19195485/63be9e6a-c8c7-49a3-b60d-a7eb58bba48b)
