### PR TITLE
chore: skaffold was not using the built image

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cloud-controller-manager
 build:
   artifacts:
-    - image: docker.io/hetznercloud/hcloud-cloud-controller-manager
+    - image: hetznercloud/hcloud-cloud-controller-manager
       docker:
         dockerfile: dev/Dockerfile
   local:


### PR DESCRIPTION
We changed the image reference in a recent PR. With this, skaffold was unable to match it against the image referenced in the Helm chart, so it always deployed the tagged version of the image.

This caused all e2e tests to not use the actual changes made in those PRs.

Noticed this because the release-please PR was trying to pull a `v1.20.0` image and failed.