### PR TITLE
feat(helm): allow setting affinity for deployment

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -52,6 +52,11 @@ spec:
         {{ toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
 
+      {{- if gt (len .Values.affinity) 0 }}
+      affinity:
+        {{ toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+
       {{- if $.Values.networking.enabled }}
       hostNetwork: true
       {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -110,6 +110,9 @@ additionalTolerations: []
 nodeSelector: {}
   # node-role.kubernetes.io/control-plane: ""
 
+# Set the affinity for pods. (Only works with kind=Deployment)
+affinity: {}
+
 robot:
   # Set to true to enable support for Robot (Dedicated) servers.
   enabled: false


### PR DESCRIPTION
Support setting the Affinity for pods of the `Deployment`.
