### PR TITLE
ci: fix flaky e2e tests by colocating registry & hccm

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -20,6 +20,10 @@ manifests:
         chartPath: chart
         setValues:
           networking.enabled: true
+          # Pulling the containers from other nodes requires working network routes, but HCCM set these up.
+          # We circumvent this by co-locating the registry & HCCM, so it's always a local pull.
+          affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey: "kubernetes.io/hostname"
+          affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchLabels.app: docker-registry
 
 profiles:
   # Clusters with Robot Servers do not support the native Routing functionality right now.


### PR DESCRIPTION
In our dev/test environment we deploy a container registry to the cluster and push our image there to avoid a dependency on external registries.

To pull from the registry, containerd is instructed to use the service IP. This IP is resolved to the Pod IP in kube-proxy. The CNI is then responsible for making a connection to the Pod IP.

In our case we have the CNI configured to use the Cloud Routes for accessing the Pod IPs from other nodes. This is only being setup by HCCM, which is a problem if we need the routes for pulling the HCCM container image.

This fixes the circular dependency by running HCCM on the same node as the registry. That way no external routes are required and the traffic stays on the same node.

This is not a problem on clusters where HCCM is pulled from an external registry or where the routes controller is not used.