### PR TITLE
chore: use fully qualified container name

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -59,7 +59,7 @@ env:
         optional: true
 
 image:
-  repository: hetznercloud/hcloud-cloud-controller-manager
+  repository: docker.io/hetznercloud/hcloud-cloud-controller-manager
   tag: 'v{{ $.Chart.Version }}'
 
 monitoring:

--- a/deploy/ccm-networks.yaml
+++ b/deploy/ccm-networks.yaml
@@ -92,7 +92,7 @@ spec:
                 secretKeyRef:
                   key: network
                   name: hcloud
-          image: hetznercloud/hcloud-cloud-controller-manager:v1.19.0 # x-release-please-version
+          image: docker.io/hetznercloud/hcloud-cloud-controller-manager:v1.19.0 # x-release-please-version
           ports:
             - name: metrics
               containerPort: 8233

--- a/deploy/ccm.yaml
+++ b/deploy/ccm.yaml
@@ -84,7 +84,7 @@ spec:
                   key: robot-user
                   name: hcloud
                   optional: true
-          image: hetznercloud/hcloud-cloud-controller-manager:v1.19.0 # x-release-please-version
+          image: docker.io/hetznercloud/hcloud-cloud-controller-manager:v1.19.0 # x-release-please-version
           ports:
             - name: metrics
               containerPort: 8233

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cloud-controller-manager
 build:
   artifacts:
-    - image: hetznercloud/hcloud-cloud-controller-manager
+    - image: docker.io/hetznercloud/hcloud-cloud-controller-manager
       docker:
         dockerfile: dev/Dockerfile
   local:


### PR DESCRIPTION
Mostly to make sure we are consistent with our other kubernetes integration: csi-driver.