### PR TITLE
feat(helm,manifests): only specify container args instead of command

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -62,8 +62,7 @@ spec:
       {{- end }}
       containers:
         - name: hcloud-cloud-controller-manager
-          command:
-            - "/bin/hcloud-cloud-controller-manager"
+          args:
             {{- range $key, $value := $.Values.args }}
             {{- if not (eq $value nil) }}
             - "--{{ $key }}{{ if $value }}={{ $value }}{{ end }}"

--- a/deploy/ccm-networks.yaml
+++ b/deploy/ccm-networks.yaml
@@ -60,8 +60,7 @@ spec:
       hostNetwork: true
       containers:
         - name: hcloud-cloud-controller-manager
-          command:
-            - "/bin/hcloud-cloud-controller-manager"
+          args:
             - "--allow-untagged-cloud"
             - "--cloud-provider=hcloud"
             - "--route-reconciliation-period=30s"

--- a/deploy/ccm.yaml
+++ b/deploy/ccm.yaml
@@ -59,8 +59,7 @@ spec:
           effect: "NoExecute"
       containers:
         - name: hcloud-cloud-controller-manager
-          command:
-            - "/bin/hcloud-cloud-controller-manager"
+          args:
             - "--allow-untagged-cloud"
             - "--cloud-provider=hcloud"
             - "--route-reconciliation-period=30s"


### PR DESCRIPTION
The container image already has the entrypoint defined. It makes no sense to duplicate this in the deployment manifests.

The hardcoded entrypoint has stopped us from introducing ko for building container images before, as ko uses another entrypoint and has no option for configuring it.