### PR TITLE
Implement support for custom internal IP mapping via HCLOUD_INSTANCES…

### DIFF
--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -147,7 +147,7 @@ func (c *cloud) Instances() (cloudprovider.Instances, bool) {
 }
 
 func (c *cloud) InstancesV2() (cloudprovider.InstancesV2, bool) {
-	return newInstances(c.client, c.robotClient, c.recorder, c.cfg.Instance.AddressFamily, c.networkID), true
+	return newInstances(c.client, c.robotClient, c.recorder, c.cfg.Instance.AddressFamily, c.networkID, c.cfg.Instance.InternalIpMap), true
 }
 
 func (c *cloud) Zones() (cloudprovider.Zones, bool) {

--- a/hcloud/instances_test.go
+++ b/hcloud/instances_test.go
@@ -89,7 +89,7 @@ func TestInstances_InstanceExists(t *testing.T) {
 		})
 	})
 
-	instances := newInstances(env.Client, env.RobotClient, env.Recorder, config.AddressFamilyIPv4, 0)
+	instances := newInstances(env.Client, env.RobotClient, env.Recorder, config.AddressFamilyIPv4, 0, map[string]string{})
 
 	tests := []struct {
 		name     string
@@ -209,7 +209,7 @@ func TestInstances_InstanceShutdown(t *testing.T) {
 		})
 	})
 
-	instances := newInstances(env.Client, env.RobotClient, env.Recorder, config.AddressFamilyIPv4, 0)
+	instances := newInstances(env.Client, env.RobotClient, env.Recorder, config.AddressFamilyIPv4, 0, map[string]string{})
 	env.Mux.HandleFunc("/robot/server/3", func(w http.ResponseWriter, _ *http.Request) {
 		json.NewEncoder(w).Encode(hrobotmodels.ServerResponse{
 			Server: hrobotmodels.Server{
@@ -343,7 +343,7 @@ func TestInstances_InstanceMetadata(t *testing.T) {
 		})
 	})
 
-	instances := newInstances(env.Client, env.RobotClient, env.Recorder, config.AddressFamilyIPv4, 0)
+	instances := newInstances(env.Client, env.RobotClient, env.Recorder, config.AddressFamilyIPv4, 0, map[string]string{})
 
 	metadata, err := instances.InstanceMetadata(context.TODO(), &corev1.Node{
 		Spec: corev1.NodeSpec{ProviderID: "hcloud://1"},
@@ -387,7 +387,7 @@ func TestInstances_InstanceMetadataRobotServer(t *testing.T) {
 		})
 	})
 
-	instances := newInstances(env.Client, env.RobotClient, env.Recorder, config.AddressFamilyIPv4, 0)
+	instances := newInstances(env.Client, env.RobotClient, env.Recorder, config.AddressFamilyIPv4, 0, map[string]string{})
 
 	metadata, err := instances.InstanceMetadata(context.TODO(), &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -581,7 +581,7 @@ func TestNodeAddresses(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			addresses := hcloudNodeAddresses(test.addressFamily, test.privateNetwork, test.server)
+			addresses := hcloudNodeAddresses(test.addressFamily, test.privateNetwork, test.server, map[string]string{})
 
 			if !reflect.DeepEqual(addresses, test.expected) {
 				t.Fatalf("Expected addresses %+v but got %+v", test.expected, addresses)
@@ -642,7 +642,7 @@ func TestNodeAddressesRobotServer(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			addresses := robotNodeAddresses(test.addressFamily, test.server)
+			addresses := robotNodeAddresses(test.addressFamily, test.server, map[string]string{})
 
 			if !reflect.DeepEqual(addresses, test.expected) {
 				t.Fatalf("%s: expected addresses %+v but got %+v", test.name, test.expected, addresses)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -24,7 +24,7 @@ func TestRead(t *testing.T) {
 			want: HCCMConfiguration{
 				Robot:        RobotConfiguration{CacheTimeout: 5 * time.Minute},
 				Metrics:      MetricsConfiguration{Enabled: true, Address: ":8233"},
-				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4},
+				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4, InternalIpMap: map[string]string{}},
 				LoadBalancer: LoadBalancerConfiguration{Enabled: true},
 			},
 			wantErr: nil,
@@ -40,7 +40,7 @@ func TestRead(t *testing.T) {
 				HCloudClient: HCloudClientConfiguration{Token: "jr5g7ZHpPptyhJzZyHw2Pqu4g9gTqDvEceYpngPf79jN_NOT_VALID_dzhepnahq"},
 				Robot:        RobotConfiguration{CacheTimeout: 5 * time.Minute},
 				Metrics:      MetricsConfiguration{Enabled: true, Address: ":8233"},
-				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4},
+				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4, InternalIpMap: map[string]string{}},
 				Network: NetworkConfiguration{
 					NameOrID: "foobar",
 				},
@@ -112,7 +112,7 @@ failed to read ROBOT_PASSWORD_FILE: open /tmp/hetzner-password: no such file or 
 				},
 				Robot:        RobotConfiguration{CacheTimeout: 5 * time.Minute},
 				Metrics:      MetricsConfiguration{Enabled: true, Address: ":8233"},
-				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4},
+				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4, InternalIpMap: map[string]string{}},
 				LoadBalancer: LoadBalancerConfiguration{Enabled: true},
 			},
 			wantErr: nil,
@@ -135,7 +135,7 @@ failed to read ROBOT_PASSWORD_FILE: open /tmp/hetzner-password: no such file or 
 					RateLimitWaitTime: 5 * time.Minute,
 				},
 				Metrics:      MetricsConfiguration{Enabled: true, Address: ":8233"},
-				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4},
+				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4, InternalIpMap: map[string]string{}},
 				LoadBalancer: LoadBalancerConfiguration{Enabled: true},
 			},
 			wantErr: nil,
@@ -148,7 +148,7 @@ failed to read ROBOT_PASSWORD_FILE: open /tmp/hetzner-password: no such file or 
 			want: HCCMConfiguration{
 				Robot:        RobotConfiguration{CacheTimeout: 5 * time.Minute},
 				Metrics:      MetricsConfiguration{Enabled: true, Address: ":8233"},
-				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv6},
+				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv6, InternalIpMap: map[string]string{}},
 				LoadBalancer: LoadBalancerConfiguration{Enabled: true},
 			},
 			wantErr: nil,
@@ -162,7 +162,7 @@ failed to read ROBOT_PASSWORD_FILE: open /tmp/hetzner-password: no such file or 
 			want: HCCMConfiguration{
 				Robot:        RobotConfiguration{CacheTimeout: 5 * time.Minute},
 				Metrics:      MetricsConfiguration{Enabled: true, Address: ":8233"},
-				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4},
+				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4, InternalIpMap: map[string]string{}},
 				LoadBalancer: LoadBalancerConfiguration{Enabled: true},
 				Network: NetworkConfiguration{
 					NameOrID:             "foobar",
@@ -181,7 +181,7 @@ failed to read ROBOT_PASSWORD_FILE: open /tmp/hetzner-password: no such file or 
 			want: HCCMConfiguration{
 				Robot:        RobotConfiguration{CacheTimeout: 5 * time.Minute},
 				Metrics:      MetricsConfiguration{Enabled: true, Address: ":8233"},
-				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4},
+				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4, InternalIpMap: map[string]string{}},
 				LoadBalancer: LoadBalancerConfiguration{Enabled: true},
 				Network: NetworkConfiguration{
 					NameOrID: "foobar",
@@ -203,7 +203,7 @@ failed to read ROBOT_PASSWORD_FILE: open /tmp/hetzner-password: no such file or 
 			want: HCCMConfiguration{
 				Robot:    RobotConfiguration{CacheTimeout: 5 * time.Minute},
 				Metrics:  MetricsConfiguration{Enabled: true, Address: ":8233"},
-				Instance: InstanceConfiguration{AddressFamily: AddressFamilyIPv4},
+				Instance: InstanceConfiguration{AddressFamily: AddressFamilyIPv4, InternalIpMap: map[string]string{}},
 				LoadBalancer: LoadBalancerConfiguration{
 					Enabled:               false,
 					Location:              "nbg1",
@@ -289,7 +289,7 @@ func TestHCCMConfiguration_Validate(t *testing.T) {
 			name: "minimal",
 			fields: fields{
 				HCloudClient: HCloudClientConfiguration{Token: "jr5g7ZHpPptyhJzZyHw2Pqu4g9gTqDvEceYpngPf79jN_NOT_VALID_dzhepnahq"},
-				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4},
+				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4, InternalIpMap: map[string]string{}},
 			},
 			wantErr: nil,
 		},
@@ -299,7 +299,7 @@ func TestHCCMConfiguration_Validate(t *testing.T) {
 			fields: fields{
 				HCloudClient: HCloudClientConfiguration{Token: "jr5g7ZHpPptyhJzZyHw2Pqu4g9gTqDvEceYpngPf79jN_NOT_VALID_dzhepnahq"},
 				Metrics:      MetricsConfiguration{Enabled: true, Address: ":8233"},
-				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4},
+				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4, InternalIpMap: map[string]string{}},
 				Network: NetworkConfiguration{
 					NameOrID: "foobar",
 				},
@@ -313,7 +313,7 @@ func TestHCCMConfiguration_Validate(t *testing.T) {
 			name: "token missing",
 			fields: fields{
 				HCloudClient: HCloudClientConfiguration{Token: ""},
-				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4},
+				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4, InternalIpMap: map[string]string{}},
 			},
 			wantErr: errors.New("environment variable \"HCLOUD_TOKEN\" is required"),
 		},
@@ -321,7 +321,7 @@ func TestHCCMConfiguration_Validate(t *testing.T) {
 			name: "token invalid length",
 			fields: fields{
 				HCloudClient: HCloudClientConfiguration{Token: "abc"},
-				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4},
+				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4, InternalIpMap: map[string]string{}},
 			},
 			wantErr: errors.New("entered token is invalid (must be exactly 64 characters long)"),
 		},
@@ -329,7 +329,7 @@ func TestHCCMConfiguration_Validate(t *testing.T) {
 			name: "address family invalid",
 			fields: fields{
 				HCloudClient: HCloudClientConfiguration{Token: "jr5g7ZHpPptyhJzZyHw2Pqu4g9gTqDvEceYpngPf79jN_NOT_VALID_dzhepnahq"},
-				Instance:     InstanceConfiguration{AddressFamily: AddressFamily("foobar")},
+				Instance:     InstanceConfiguration{AddressFamily: AddressFamily("foobar"), InternalIpMap: map[string]string{}},
 			},
 			wantErr: errors.New("invalid value for \"HCLOUD_INSTANCES_ADDRESS_FAMILY\", expect one of: ipv4,ipv6,dualstack"),
 		},
@@ -337,7 +337,7 @@ func TestHCCMConfiguration_Validate(t *testing.T) {
 			name: "LB location and network zone set",
 			fields: fields{
 				HCloudClient: HCloudClientConfiguration{Token: "jr5g7ZHpPptyhJzZyHw2Pqu4g9gTqDvEceYpngPf79jN_NOT_VALID_dzhepnahq"},
-				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4},
+				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4, InternalIpMap: map[string]string{}},
 				LoadBalancer: LoadBalancerConfiguration{
 					Location:    "nbg1",
 					NetworkZone: "eu-central",
@@ -349,7 +349,7 @@ func TestHCCMConfiguration_Validate(t *testing.T) {
 			name: "robot enabled but missing credentials",
 			fields: fields{
 				HCloudClient: HCloudClientConfiguration{Token: "jr5g7ZHpPptyhJzZyHw2Pqu4g9gTqDvEceYpngPf79jN_NOT_VALID_dzhepnahq"},
-				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4},
+				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4, InternalIpMap: map[string]string{}},
 
 				Robot: RobotConfiguration{
 					Enabled: true,
@@ -363,7 +363,7 @@ environment variable "ROBOT_PASSWORD" is required if Robot support is enabled`),
 			fields: fields{
 
 				HCloudClient: HCloudClientConfiguration{Token: "jr5g7ZHpPptyhJzZyHw2Pqu4g9gTqDvEceYpngPf79jN_NOT_VALID_dzhepnahq"},
-				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4},
+				Instance:     InstanceConfiguration{AddressFamily: AddressFamilyIPv4, InternalIpMap: map[string]string{}},
 				Route:        RouteConfiguration{Enabled: true},
 				Robot: RobotConfiguration{
 					Enabled: true,


### PR DESCRIPTION
This update adds the ability to specify custom internal IP addresses for Hetzner Cloud and Robot Instances through the `HCLOUD_INSTANCES_INTERNAL_IP_MAP` environment variable.

This is especially useful when mixing cloud servers with dedicated robot servers via vSwitch / private networks. Users will need to manage the IPs of the robot servers manually anyway, this change let users specify them as well for the InternalIp field in K8S.

To use this set `HCLOUD_INSTANCES_INTERNAL_IP_MAP` to a commaseparated list of node-name/IP-pairs, e.g.
```
root1=172.16.1.2,root2=172.16.1.3,root3=172.16.1.4,root4=172.16.1.5,root5=172.16.1.6,root6=172.16.1.7
```