### PR TITLE
fix: wrong version logged on startup

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,6 +23,7 @@ builds:
       - -s
       - -w
       - -X github.com/hetznercloud/hcloud-cloud-controller-manager/hcloud.providerVersion={{ if not .IsSnapshot }}v{{ end }}{{ .Version }}
+      - -X k8s.io/component-base/version.gitVersion={{ if not .IsSnapshot }}v{{ end }}{{ .Version }}
 
 dockers:
   - build_flag_templates: [--platform=linux/amd64]


### PR DESCRIPTION
The k/cloud-provider library is logging a version on startup. This version is expected to be set by Kubernetes build scripts, but we do not use this.

Right now it looks like this:

```
controllermanager.go:169] Version: v0.0.0-master+$Format:%H$
```

With the fix, this will report the same version as we use for the user-agent.