### PR TITLE
Skip udp service ports as loadbalancers do not support UDP

### DIFF
--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -842,6 +842,11 @@ func (l *LoadBalancerOps) ReconcileHCLBServices(
 		)
 
 		portNo := int(port.Port)
+		if port.Protocol == corev1.ProtocolUDP {
+			klog.InfoS("skipping port, load balancers do not support UDP", "op", op, "port", portNo, "loadBalancerID", lb.ID)
+			continue
+		}
+
 		portExists := hclbListenPorts[portNo]
 		delete(hclbListenPorts, portNo)
 


### PR DESCRIPTION
If a loadbalancer svc includes both tcp and udp for the same port, for example 53/tcp and 53/udp for dns, the CCM will currently fail to create the loadbalancer due to duplicate ports, but the CCM should ignore the UDP port as loadbalancers do not support udp.