### PR TITLE
fix: change annotation LBSvcRedirectHTTP to "https"

### DIFF
--- a/internal/annotation/load_balancer.go
+++ b/internal/annotation/load_balancer.go
@@ -162,7 +162,7 @@ const (
 	LBSvcHTTPManagedCertificateDomains Name = "load-balancer.hetzner.cloud/http-managed-certificate-domains"
 
 	// LBSvcRedirectHTTP create a redirect from HTTP to HTTPS. HTTPS only.
-	LBSvcRedirectHTTP Name = "load-balancer.hetzner.cloud/http-redirect-http"
+	LBSvcRedirectHTTP Name = "load-balancer.hetzner.cloud/http-redirect-https"
 
 	// LBSvcHTTPStickySessions enables the sticky sessions feature of Hetzner
 	// Cloud HTTP Load Balancers.


### PR DESCRIPTION
Hi,

I think this should be renamed from "http-to-http" to "http-to-https" and this would be a breaking change.

Closes #656 

Kind regards