### PR TITLE
Allow arbitrary length API token behind a flag

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,10 +11,11 @@ import (
 )
 
 const (
-	hcloudToken    = "HCLOUD_TOKEN"
-	hcloudEndpoint = "HCLOUD_ENDPOINT"
-	hcloudNetwork  = "HCLOUD_NETWORK"
-	hcloudDebug    = "HCLOUD_DEBUG"
+	hcloudToken                     = "HCLOUD_TOKEN"
+	hcloudAllowArbitraryLengthToken = "HCLOUD_ALLOW_ARBITRARY_LENGTH_TOKEN"
+	hcloudEndpoint                  = "HCLOUD_ENDPOINT"
+	hcloudNetwork                   = "HCLOUD_NETWORK"
+	hcloudDebug                     = "HCLOUD_DEBUG"
 
 	robotEnabled           = "ROBOT_ENABLED"
 	robotUser              = "ROBOT_USER"
@@ -40,9 +41,10 @@ const (
 )
 
 type HCloudClientConfiguration struct {
-	Token    string
-	Endpoint string
-	Debug    bool
+	Token                     string
+	AllowArbitraryLengthToken bool
+	Endpoint                  string
+	Debug                     bool
 }
 
 type RobotConfiguration struct {
@@ -109,6 +111,10 @@ func Read() (HCCMConfiguration, error) {
 	var cfg HCCMConfiguration
 
 	cfg.HCloudClient.Token, err = envutil.LookupEnvWithFile(hcloudToken)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	cfg.HCloudClient.AllowArbitraryLengthToken, err = getEnvBool(hcloudAllowArbitraryLengthToken, false)
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -201,7 +207,7 @@ func (c HCCMConfiguration) Validate() (err error) {
 
 	if c.HCloudClient.Token == "" {
 		errs = append(errs, fmt.Errorf("environment variable %q is required", hcloudToken))
-	} else if len(c.HCloudClient.Token) != 64 {
+	} else if !c.HCloudClient.AllowArbitraryLengthToken && len(c.HCloudClient.Token) != 64 {
 		errs = append(errs, fmt.Errorf("entered token is invalid (must be exactly 64 characters long)"))
 	}
 


### PR DESCRIPTION
# Context
[We](https://github.com/altinity) have developed a soon-to-be-open-source proxy that forces specific labels in order to provide scoped API access, and that doesn't expose the real API token. This was created to have better control of resources inside the same project (as API tokens currently lack granularity), and to be able to use a single project securely, given that it isn't possible to create a project via the API.

One of it's operating modes is using JWT as a virtual self-validating token, which can't have a fixed size.

This support is required to make full use of it inside a Kubernetes cluster. 

The feature is behind a default-false flag so it shouldn't interfere with current behavior.

# Related
https://github.com/kubernetes/autoscaler/pull/7285
https://github.com/hetznercloud/csi-driver/pull/724