### PR TITLE
Document disabling route controller for self-managed networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,10 @@ If you want to use the Hetzner Cloud `Networks` Feature, head over to
 the [Deployment with Networks support
 documentation](./docs/deploy_with_networks.md).
 
-If you manage the network yourself it might still be required to let the CCM know about private networks. You can do
-this by adding the environment variable
-with the network name/ID in the CCM deployment.
+If you manage the network yourself it might still be required to let the CCM know about private networks. For example,
+even with a self-managed network, it's still possible to enable private network attachment of CCM-provisioned Load
+Balancers by setting the `load-balancer.hetzner.cloud/use-private-ip` annotation to `true` on the Kubernetes Service.
+This functionality requires setting the following environment variables in the CCM deployment:
 
 ```
           env:
@@ -153,6 +154,8 @@ with the network name/ID in the CCM deployment.
                 secretKeyRef:
                   name: hcloud
                   key: network
+            - name: HCLOUD_NETWORK_ROUTES_ENABLED
+              value: "false"
 ```
 
 You also need to add the network name/ID to the


### PR DESCRIPTION
Currently the README appears to provide incomplete instructions when using self-managed networks with HCCM.  Per #758 setting `HCLOUD_NETWORK` alone isn't enough as HCCM enables the route controller and fails.  Setting `HCLOUD_NETWORK_ROUTES_ENABLED` to false is also required for the self-managed network scenario.

This PR adds that to the documentation, and also offers a tip to enable the `load-balancer.hetzner.cloud/use-private-ip` annotation on the K8s service (at least in lieu of full documentation of supported annotations).

If there's a valid use case for self-managed network with route controller enabled, please let me know and I"m happy to refine the PR to clarify that.

Fixes #758 