### PR TITLE
fix: invalid characters in label instance-type of robot servers

### DIFF
--- a/hcloud/instances_test.go
+++ b/hcloud/instances_test.go
@@ -380,7 +380,7 @@ func TestInstances_InstanceMetadataRobotServer(t *testing.T) {
 				ServerIP:      "233.252.0.123",
 				ServerIPv6Net: "2a01:f48:111:4221::",
 				ServerNumber:  321,
-				Product:       "robot-product 1",
+				Product:       "Robot Server™ 1",
 				Name:          "robot-server1",
 				Dc:            "NBG1-DC1",
 			},
@@ -401,7 +401,7 @@ func TestInstances_InstanceMetadataRobotServer(t *testing.T) {
 
 	expectedMetadata := &cloudprovider.InstanceMetadata{
 		ProviderID:   "hrobot://321",
-		InstanceType: "robot-product-1",
+		InstanceType: "Robot-Server-1",
 		NodeAddresses: []corev1.NodeAddress{
 			{Type: corev1.NodeHostName, Address: "robot-server1"},
 			{Type: corev1.NodeExternalIP, Address: "233.252.0.123"},

--- a/hcloud/instances_util.go
+++ b/hcloud/instances_util.go
@@ -19,6 +19,7 @@ package hcloud
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	hrobotmodels "github.com/syself/hrobot-go/models"
@@ -102,7 +103,9 @@ func getInstanceTypeOfRobotServer(server *hrobotmodels.Server) string {
 	if server == nil {
 		panic("getInstanceTypeOfRobotServer called with nil server")
 	}
-	return strings.ReplaceAll(server.Product, " ", "-")
+	productName := strings.ReplaceAll(server.Product, " ", "-")
+	// Removes all characters that are invalid for a Kubernetes label
+	return regexp.MustCompile(`[^a-zA-Z0-9_.-]+`).ReplaceAllString(productName, "")
 }
 
 func getZoneOfRobotServer(server *hrobotmodels.Server) string {


### PR DESCRIPTION
Invalid characters like `™` should be removed when generating the instance-type label for Robot servers.