### PR TITLE
feat: emit event when robot server name and node name mismatch

### DIFF
--- a/hcloud/instances.go
+++ b/hcloud/instances.go
@@ -85,7 +85,7 @@ func (i *instances) lookupServer(
 		if i.robotClient == nil {
 			return nil, errMissingRobotClient
 		}
-		server, err := getRobotServerByID(i.robotClient, int(serverID), node)
+		server, err := getRobotServerByID(i, int(serverID), node)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get robot server \"%d\": %w", serverID, err)
 		}

--- a/hcloud/instances_util.go
+++ b/hcloud/instances_util.go
@@ -96,7 +96,7 @@ func getRobotServerByID(i *instances, id int, node *corev1.Node) (*hrobotmodels.
 			node,
 			corev1.EventTypeWarning,
 			"PossibleNodeDeletion",
-			"Might be deleted by node-lifecycle-manager due to name mismatch; Node name \"%s\" differs from Robot name \"%s\"",
+			"Might be deleted by node-lifecycle-manager due to name mismatch; Node name %q differs from Robot name %q",
 			node.ObjectMeta.Name,
 			server.Name,
 		)


### PR DESCRIPTION
When the Robot server name is changed in the Robot console or via the API the node might be deleted by the node-lifecycle-manager. We now emit a warning event for this case.