### PR TITLE
feat(load-balancer): ignore nodes that don't use known provider IDs

### DIFF
--- a/hcloud/instances.go
+++ b/hcloud/instances.go
@@ -113,7 +113,13 @@ func (i *instances) lookupServer(
 	}
 
 	if cloudServer != nil && hrobotServer != nil {
-		i.recorder.Eventf(node, corev1.EventTypeWarning, "InstanceLookupFailed", "Node %s could not be uniquely associated with a Cloud or Robot server, as a server with this name exists in both APIs", node.Name)
+		i.recorder.Eventf(
+			node,
+			corev1.EventTypeWarning,
+			"InstanceLookupFailed",
+			"Node %s could not be uniquely associated with a Cloud or Robot server, as a server with this name exists in both APIs",
+			node.Name,
+		)
 		return nil, fmt.Errorf("found both a cloud & robot server for name %q", node.Name)
 	}
 

--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -613,7 +613,7 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 	for _, node := range nodes {
 		id, isCloudServer, err := providerid.ToServerID(node.Spec.ProviderID)
 		if err != nil {
-			if errors.Is(err, &providerid.UnkownPrefixError{}) {
+			if errors.As(err, new(*providerid.UnkownPrefixError)) {
 				// ProviderID has unknown prefix, cluster might have non-hccm nodes that can not be added to the
 				// Load Balancer. Emitting an event and ignoring that Node in this reconciliation loop.
 				l.Recorder.Eventf(

--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -613,6 +613,18 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 	for _, node := range nodes {
 		id, isCloudServer, err := providerid.ToServerID(node.Spec.ProviderID)
 		if err != nil {
+			if errors.Is(err, &providerid.UnkownPrefixError{}) {
+				// ProviderID has unknown prefix, cluster might have non-hccm nodes that can not be added to the
+				// Load Balancer. Emitting an event and ignoring that Node in this reconciliation loop.
+				l.Recorder.Eventf(
+					node,
+					corev1.EventTypeWarning,
+					"UnknownProviderIDPrefix",
+					"Node could not be added to Load Balancer for service %s because the provider ID does not match any known format",
+					svc.Name,
+				)
+				continue
+			}
 			return changed, fmt.Errorf("%s: %w", op, err)
 		}
 		if isCloudServer {

--- a/internal/providerid/providerid.go
+++ b/internal/providerid/providerid.go
@@ -30,7 +30,7 @@ type UnkownPrefixError struct {
 
 func (e *UnkownPrefixError) Error() string {
 	return fmt.Sprintf(
-		"providerID does not have one of the the expected prefixes (%s, %s, %s): %s",
+		"Provider ID does not have one of the the expected prefixes (%s, %s, %s): %s",
 		prefixCloud,
 		prefixRobot,
 		prefixRobotLegacy,

--- a/internal/providerid/providerid.go
+++ b/internal/providerid/providerid.go
@@ -24,6 +24,20 @@ const (
 	prefixRobotLegacy = "hcloud://bm-"
 )
 
+type UnkownPrefixError struct {
+	ProviderID string
+}
+
+func (e *UnkownPrefixError) Error() string {
+	return fmt.Sprintf(
+		"providerID does not have one of the the expected prefixes (%s, %s, %s): %s",
+		prefixCloud,
+		prefixRobot,
+		prefixRobotLegacy,
+		e.ProviderID,
+	)
+}
+
 // ToServerID parses the Cloud or Robot Server ID from a ProviderID.
 //
 // This method supports all formats for the ProviderID that were ever used.
@@ -44,7 +58,7 @@ func ToServerID(providerID string) (id int64, isCloudServer bool, err error) {
 		idString = strings.ReplaceAll(providerID, prefixCloud, "")
 
 	default:
-		return 0, false, fmt.Errorf("providerID does not have one of the the expected prefixes (%s, %s, %s): %s", prefixCloud, prefixRobot, prefixRobotLegacy, providerID)
+		return 0, false, &UnkownPrefixError{providerID}
 	}
 
 	if idString == "" {


### PR DESCRIPTION
With this feature the load balancer is more resilient to hybrid clusters as it skips nodes with unkown provider ids.