### PR TITLE
fix: request flood when misconfigured cluster-cidr causes dead routes to be kept

### DIFF
--- a/hcloud/routes.go
+++ b/hcloud/routes.go
@@ -119,6 +119,18 @@ func (r *routes) CreateRoute(ctx context.Context, clusterName string, nameHint s
 		return fmt.Errorf("%s: %w", op, err)
 	}
 
+	hNetSize, _ := r.network.IPRange.Mask.Size()
+	destNetSize, _ := cidr.Mask.Size()
+
+	if !(r.network.IPRange.Contains(cidr.IP) && destNetSize >= hNetSize) {
+		return fmt.Errorf(
+			"route CIDR %s is not contained within CIDR %s of hcloud network %d",
+			route.DestinationCIDR,
+			r.network.IPRange.String(),
+			r.network.ID,
+		)
+	}
+
 	doesRouteAlreadyExist, err := r.checkIfRouteAlreadyExists(ctx, route)
 	if err != nil {
 		return fmt.Errorf("%s: %w", op, err)

--- a/hcloud/routes_test.go
+++ b/hcloud/routes_test.go
@@ -83,6 +83,15 @@ func TestRoutes_CreateRoute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
+
+	err = routes.CreateRoute(context.TODO(), "my-cluster", "routeFail", &cloudprovider.Route{
+		Name:            "route",
+		TargetNode:      "node15",
+		DestinationCIDR: "172.16.0.0/16",
+	})
+	if err == nil {
+		t.Fatalf("Expected an error because DestinationCIDR is not within the cluster CIDR, but received nil instead")
+	}
 }
 
 func TestRoutes_ListRoutes(t *testing.T) {


### PR DESCRIPTION
Before adding a route, verify if the route CIDR is contained within the cluster CIDR. If it is not, return an error to prevent a flood of requests caused by persistent dead routes.

Fixes #482 