### PR TITLE
feat(routes): emit warning if cluster cidr is misconfigured

### DIFF
--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -51,9 +51,10 @@ type cloud struct {
 	cfg         config.HCCMConfiguration
 	recorder    record.EventRecorder
 	networkID   int64
+	cidr        string
 }
 
-func NewCloud() (cloudprovider.Interface, error) {
+func NewCloud(cidr string) (cloudprovider.Interface, error) {
 	const op = "hcloud/newCloud"
 	metrics.OperationCalled.WithLabelValues(op).Inc()
 
@@ -131,6 +132,7 @@ func NewCloud() (cloudprovider.Interface, error) {
 		robotClient: robotClient,
 		cfg:         cfg,
 		networkID:   networkID,
+		cidr:        cidr,
 	}, nil
 }
 
@@ -192,7 +194,12 @@ func (c *cloud) Routes() (cloudprovider.Routes, bool) {
 		return nil, false
 	}
 
-	r, err := newRoutes(c.client, c.networkID)
+	r, err := newRoutes(
+		c.client,
+		c.networkID,
+		c.cidr,
+		c.recorder,
+	)
 	if err != nil {
 		klog.ErrorS(err, "create routes provider", "networkID", c.networkID)
 		return nil, false

--- a/hcloud/cloud_test.go
+++ b/hcloud/cloud_test.go
@@ -92,7 +92,7 @@ func TestNewCloud(t *testing.T) {
 		)
 	})
 
-	_, err := NewCloud()
+	_, err := NewCloud(DefaultClusterCIDR)
 	assert.NoError(t, err)
 }
 
@@ -104,7 +104,7 @@ func TestNewCloudConnectionNotPossible(t *testing.T) {
 	)
 	defer resetEnv()
 
-	_, err := NewCloud()
+	_, err := NewCloud(DefaultClusterCIDR)
 	assert.EqualError(t, err,
 		`hcloud/newCloud: Get "http://127.0.0.1:4711/v1/servers?": dial tcp 127.0.0.1:4711: connect: connection refused`)
 }
@@ -132,7 +132,7 @@ func TestNewCloudInvalidToken(t *testing.T) {
 		)
 	})
 
-	_, err := NewCloud()
+	_, err := NewCloud(DefaultClusterCIDR)
 	assert.EqualError(t, err, "hcloud/newCloud: unable to authenticate (unauthorized)")
 }
 
@@ -195,7 +195,7 @@ func TestCloud(t *testing.T) {
 		)
 	})
 
-	cloud, err := NewCloud()
+	cloud, err := NewCloud(DefaultClusterCIDR)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestCloud(t *testing.T) {
 		)
 		defer resetEnv()
 
-		c, err := NewCloud()
+		c, err := NewCloud(DefaultClusterCIDR)
 		if err != nil {
 			t.Errorf("%s", err)
 		}

--- a/hcloud/routes.go
+++ b/hcloud/routes.go
@@ -119,6 +119,18 @@ func (r *routes) CreateRoute(ctx context.Context, clusterName string, nameHint s
 		return fmt.Errorf("%s: %w", op, err)
 	}
 
+	hNetSize, _ := r.network.IPRange.Mask.Size()
+	destNetSize, _ := cidr.Mask.Size()
+
+	if !(r.network.IPRange.Contains(cidr.IP) && destNetSize >= hNetSize) {
+		return fmt.Errorf(
+			"route CIDR %s is not contained within CIDR %s of hcloud network %d",
+			route.DestinationCIDR,
+			r.network.IPRange.String(),
+			r.network.ID,
+		)
+	}
+
 	doesRouteAlreadyExist, err := r.checkIfRouteAlreadyExists(ctx, route)
 	if err != nil {
 		return fmt.Errorf("%s: %w", op, err)

--- a/hcloud/routes.go
+++ b/hcloud/routes.go
@@ -20,8 +20,6 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-const DefaultClusterCIDR = "10.244.0.0/16"
-
 var (
 	serversCacheMissRefreshRate = rate.Every(30 * time.Second)
 )

--- a/hcloud/routes_test.go
+++ b/hcloud/routes_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
+const DefaultClusterCIDR = "10.244.0.0/16"
+
 func TestRoutes_CreateRoute(t *testing.T) {
 	env := newTestEnv()
 	defer env.Teardown()

--- a/hcloud/routes_test.go
+++ b/hcloud/routes_test.go
@@ -83,6 +83,15 @@ func TestRoutes_CreateRoute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
+
+	err = routes.CreateRoute(context.TODO(), "my-cluster", "routeFail", &cloudprovider.Route{
+		Name:            "route",
+		TargetNode:      "node15",
+		DestinationCIDR: "172.16.0.0/16",
+	})
+	if err == nil {
+		t.Fatalf("Expected an error because DestinationCIDR is not within the cluster CIDR, but received nil instead")
+	}
 }
 
 func TestRoutes_ListRoutes(t *testing.T) {

--- a/hcloud/routes_test.go
+++ b/hcloud/routes_test.go
@@ -70,7 +70,7 @@ func TestRoutes_CreateRoute(t *testing.T) {
 			},
 		})
 	})
-	routes, err := newRoutes(env.Client, 1)
+	routes, err := newRoutes(env.Client, 1, DefaultClusterCIDR, env.Recorder)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -82,15 +82,6 @@ func TestRoutes_CreateRoute(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	err = routes.CreateRoute(context.TODO(), "my-cluster", "routeFail", &cloudprovider.Route{
-		Name:            "route",
-		TargetNode:      "node15",
-		DestinationCIDR: "172.16.0.0/16",
-	})
-	if err == nil {
-		t.Fatalf("Expected an error because DestinationCIDR is not within the cluster CIDR, but received nil instead")
 	}
 }
 
@@ -128,7 +119,7 @@ func TestRoutes_ListRoutes(t *testing.T) {
 			},
 		})
 	})
-	routes, err := newRoutes(env.Client, 1)
+	routes, err := newRoutes(env.Client, 1, DefaultClusterCIDR, env.Recorder)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -196,7 +187,7 @@ func TestRoutes_DeleteRoute(t *testing.T) {
 			},
 		})
 	})
-	routes, err := newRoutes(env.Client, 1)
+	routes, err := newRoutes(env.Client, 1, DefaultClusterCIDR, env.Recorder)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 }
 
 func cloudInitializer(config *config.CompletedConfig) cloudprovider.Interface {
-	cloud, err := hcloud.NewCloud()
+	cloud, err := hcloud.NewCloud(config.ComponentConfig.KubeCloudShared.ClusterCIDR)
 	if err != nil {
 		klog.Fatalf("Cloud provider could not be initialized: %v", err)
 	}


### PR DESCRIPTION
Before adding a route, verify if the route CIDR is contained within the configured cluster CIDR. If it is not, emit a warning event and log message.