### PR TITLE
refactor: simplified hccm init code

### DIFF
--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -19,7 +19,6 @@ package hcloud
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 
@@ -54,7 +53,7 @@ type cloud struct {
 	networkID   int64
 }
 
-func newCloud(_ io.Reader) (cloudprovider.Interface, error) {
+func NewCloud() (cloudprovider.Interface, error) {
 	const op = "hcloud/newCloud"
 	metrics.OperationCalled.WithLabelValues(op).Inc()
 
@@ -221,8 +220,4 @@ func serverIsAttachedToNetwork(metadataClient *metadata.Client, networkID int64)
 		return false, fmt.Errorf("%s: %s", op, err)
 	}
 	return strings.Contains(serverPrivateNetworks, fmt.Sprintf("network_id: %d\n", networkID)), nil
-}
-
-func init() {
-	cloudprovider.RegisterCloudProvider(providerName, newCloud)
 }

--- a/hcloud/cloud_test.go
+++ b/hcloud/cloud_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package hcloud
 
 import (
-	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -92,8 +91,8 @@ func TestNewCloud(t *testing.T) {
 			},
 		)
 	})
-	var config bytes.Buffer
-	_, err := newCloud(&config)
+
+	_, err := NewCloud()
 	assert.NoError(t, err)
 }
 
@@ -105,7 +104,7 @@ func TestNewCloudConnectionNotPossible(t *testing.T) {
 	)
 	defer resetEnv()
 
-	_, err := newCloud(&bytes.Buffer{})
+	_, err := NewCloud()
 	assert.EqualError(t, err,
 		`hcloud/newCloud: Get "http://127.0.0.1:4711/v1/servers?": dial tcp 127.0.0.1:4711: connect: connection refused`)
 }
@@ -133,7 +132,7 @@ func TestNewCloudInvalidToken(t *testing.T) {
 		)
 	})
 
-	_, err := newCloud(&bytes.Buffer{})
+	_, err := NewCloud()
 	assert.EqualError(t, err, "hcloud/newCloud: unable to authenticate (unauthorized)")
 }
 
@@ -196,7 +195,7 @@ func TestCloud(t *testing.T) {
 		)
 	})
 
-	cloud, err := newCloud(&bytes.Buffer{})
+	cloud, err := NewCloud()
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -253,7 +252,7 @@ func TestCloud(t *testing.T) {
 		)
 		defer resetEnv()
 
-		c, err := newCloud(&bytes.Buffer{})
+		c, err := NewCloud()
 		if err != nil {
 			t.Errorf("%s", err)
 		}

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ import (
 	_ "k8s.io/component-base/metrics/prometheus/version"
 	"k8s.io/klog/v2"
 
-	_ "github.com/hetznercloud/hcloud-cloud-controller-manager/hcloud"
+	hcloud "github.com/hetznercloud/hcloud-cloud-controller-manager/hcloud"
 )
 
 func main() {
@@ -59,10 +59,7 @@ func main() {
 }
 
 func cloudInitializer(config *config.CompletedConfig) cloudprovider.Interface {
-	cloudConfig := config.ComponentConfig.KubeCloudShared.CloudProvider
-
-	// initialize cloud provider with the cloud provider name and config file provided
-	cloud, err := cloudprovider.InitCloudProvider(cloudConfig.Name, cloudConfig.CloudConfigFile)
+	cloud, err := hcloud.NewCloud()
 	if err != nil {
 		klog.Fatalf("Cloud provider could not be initialized: %v", err)
 	}


### PR DESCRIPTION
Removed the `cloudprovider.InitCloudProvider` initialization process to simplify the codebase and enhance maintainability.