### PR TITLE
style: replaced deprecated linter exportloopref with copyloopvar

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,10 +29,10 @@ linters:
   disable-all: true
   enable:
     - bodyclose
+    - copyloopvar
     - errcheck
     - errname
     - exhaustive
-    - exportloopref
     - gci
     - gocritic
     - godot

--- a/hcloud/load_balancers_test.go
+++ b/hcloud/load_balancers_test.go
@@ -948,7 +948,6 @@ func TestLoadBalancer_matchNodeSelector(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c // prevent scopelint from complaining
 		t.Run(c.name, func(t *testing.T) {
 			nodes, err := matchNodeSelector(c.service, c.k8sNodes)
 			if err != nil {

--- a/internal/annotation/load_balancer_test.go
+++ b/internal/annotation/load_balancer_test.go
@@ -159,7 +159,6 @@ func TestLBToService_AddAnnotations(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := annotation.LBToService(&tt.svc, &tt.lb)
 			assert.NoError(t, err)

--- a/internal/annotation/name_test.go
+++ b/internal/annotation/name_test.go
@@ -88,7 +88,6 @@ func TestName_AddToService(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := ann.AnnotateService(&tt.svc, tt.value)
 			if tt.err != nil {
@@ -123,7 +122,6 @@ func TestName_StringFromService(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var svc corev1.Service
 
@@ -478,7 +476,6 @@ func runAllTypedAccessorTests(
 	t.Helper()
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tt.run(t, call)
 		})

--- a/internal/hcops/certificates_test.go
+++ b/internal/hcops/certificates_test.go
@@ -227,7 +227,6 @@ func (tt *certificateOpsTestCase) run(t *testing.T) {
 
 func runCertificateOpsTestCases(t *testing.T, tests []certificateOpsTestCase) {
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.Name, tt.run)
 	}
 }

--- a/internal/hcops/load_balancer_internal_test.go
+++ b/internal/hcops/load_balancer_internal_test.go
@@ -363,7 +363,6 @@ func TestHCLBServiceOptsBuilder(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tt.certClient = &mocks.CertificateClient{}
 			tt.certClient.Test(t)

--- a/internal/hcops/load_balancer_test.go
+++ b/internal/hcops/load_balancer_test.go
@@ -76,7 +76,6 @@ func TestLoadBalancerOps_GetByName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			fx := hcops.NewLoadBalancerOpsFixture(t)
 			if tt.mock != nil {
@@ -146,7 +145,6 @@ func TestLoadBalancerOps_GetByID(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			fx := hcops.NewLoadBalancerOpsFixture(t)
 			if tt.mock != nil {
@@ -201,7 +199,6 @@ func TestGetByK8SServiceUID(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			fx := hcops.NewLoadBalancerOpsFixture(t)
 
@@ -463,7 +460,6 @@ func TestLoadBalancerOps_Create(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			fx := hcops.NewLoadBalancerOpsFixture(t)
 
@@ -525,7 +521,6 @@ func TestLoadBalancerOps_Delete(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			fx := hcops.NewLoadBalancerOpsFixture(t)
 			ctx := context.Background()
@@ -1137,7 +1132,6 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, tt.run)
 	}
 }
@@ -1421,7 +1415,6 @@ func TestLoadBalancerOps_ReconcileHCLBTargets(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, tt.run)
 	}
 }
@@ -1700,7 +1693,6 @@ func TestLoadBalancerOps_ReconcileHCLBServices(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, tt.run)
 	}
 }


### PR DESCRIPTION
Updated golangci-lint configuration and resolved all linting issues identified by the updated settings.