### PR TITLE
ci: fix missing version update in Chart.yaml

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: hcloud-cloud-controller-manager
 type: application
-version: 1.20.0
+version: 1.20.0 # x-releaser-pleaser-version


### PR DESCRIPTION
`release-please` automatically found and updated the file, this no longer works with `releaser-pleaser` and it requires the marker.