### PR TITLE
feat(load-balancer): emit warning if unsupported port protocol is configured

### DIFF
--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -845,16 +845,16 @@ func (l *LoadBalancerOps) ReconcileHCLBServices(
 		return false, fmt.Errorf("%s: %v", op, err)
 	}
 
-    for _, port := range svc.Spec.Ports {
-        if port.Protocol != "" && port.Protocol != corev1.ProtocolTCP {
-            err := fmt.Errorf(
-                "configured unsupported Hetzner Cloud load balancer protocol %s for service with name %s",
-                port.Protocol,
-                svc.Name,
-            )
-            return false, err
-        }
-    }
+	for _, port := range svc.Spec.Ports {
+		if port.Protocol != "" && port.Protocol != corev1.ProtocolTCP {
+			err := fmt.Errorf(
+				"configured unsupported Hetzner Cloud load balancer protocol %s for service with name %s",
+				port.Protocol,
+				svc.Name,
+			)
+			return false, err
+		}
+	}
 
 	hclbListenPorts := make(map[int]bool, len(lb.Services))
 	for _, hclbService := range lb.Services {

--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -867,16 +867,16 @@ func (l *LoadBalancerOps) ReconcileHCLBServices(
 		delete(hclbListenPorts, portNo)
 
 		if port.Protocol != "" && port.Protocol != corev1.ProtocolTCP {
-            warnMsg := fmt.Sprintf(
+			warnMsg := fmt.Sprintf(
 				"configured unsupported Hetzner Cloud load balancer protocol %s for service with name %s",
 				port.Protocol,
 				svc.Name,
-            )
+			)
 			l.Recorder.Event(
 				svc,
 				corev1.EventTypeWarning,
 				"UnsupportedProtocolConfigured",
-                warnMsg,
+				warnMsg,
 			)
 			klog.Warning(warnMsg)
 		}

--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -845,6 +845,17 @@ func (l *LoadBalancerOps) ReconcileHCLBServices(
 		return false, fmt.Errorf("%s: %v", op, err)
 	}
 
+    for _, port := range svc.Spec.Ports {
+        if port.Protocol != "" && port.Protocol != corev1.ProtocolTCP {
+            err := fmt.Errorf(
+                "configured unsupported Hetzner Cloud load balancer protocol %s for service with name %s",
+                port.Protocol,
+                svc.Name,
+            )
+            return false, err
+        }
+    }
+
 	hclbListenPorts := make(map[int]bool, len(lb.Services))
 	for _, hclbService := range lb.Services {
 		hclbListenPorts[hclbService.ListenPort] = true

--- a/internal/hcops/load_balancer_test.go
+++ b/internal/hcops/load_balancer_test.go
@@ -1449,6 +1449,17 @@ func TestLoadBalancerOps_ReconcileHCLBTargets(t *testing.T) {
 func TestLoadBalancerOps_ReconcileHCLBServices(t *testing.T) {
 	tests := []LBReconcilementTestCase{
 		{
+			name: "configure unsupported protocol",
+			servicePorts: []corev1.ServicePort{
+				{Port: 80, NodePort: 8080, Protocol: corev1.ProtocolUDP},
+				{Port: 443, NodePort: 8443, Protocol: corev1.ProtocolUDP},
+			},
+			perform: func(t *testing.T, tt *LBReconcilementTestCase) {
+				_, err := tt.fx.LBOps.ReconcileHCLBServices(tt.fx.Ctx, tt.initialLB, tt.service)
+				assert.Error(t, err)
+			},
+		},
+		{
 			name: "add services to hc Load Balancer",
 			servicePorts: []corev1.ServicePort{
 				{Port: 80, NodePort: 8080},

--- a/internal/hcops/load_balancer_test.go
+++ b/internal/hcops/load_balancer_test.go
@@ -1454,9 +1454,40 @@ func TestLoadBalancerOps_ReconcileHCLBServices(t *testing.T) {
 				{Port: 80, NodePort: 8080, Protocol: corev1.ProtocolUDP},
 				{Port: 443, NodePort: 8443, Protocol: corev1.ProtocolUDP},
 			},
+			initialLB: &hcloud.LoadBalancer{
+				ID: 4,
+				LoadBalancerType: &hcloud.LoadBalancerType{
+					MaxTargets: 25,
+				},
+			},
+			mock: func(_ *testing.T, tt *LBReconcilementTestCase) {
+				opts := hcloud.LoadBalancerAddServiceOpts{
+					Protocol:        hcloud.LoadBalancerServiceProtocolTCP,
+					ListenPort:      hcloud.Ptr(80),
+					DestinationPort: hcloud.Ptr(8080),
+					HealthCheck: &hcloud.LoadBalancerAddServiceOptsHealthCheck{
+						Protocol: hcloud.LoadBalancerServiceProtocolTCP,
+						Port:     hcloud.Ptr(8080),
+					},
+				}
+				action := tt.fx.MockAddService(opts, tt.initialLB, nil)
+				tt.fx.ActionClient.On("WaitFor", tt.fx.Ctx, action).Return(nil)
+
+				opts = hcloud.LoadBalancerAddServiceOpts{
+					Protocol:        hcloud.LoadBalancerServiceProtocolTCP,
+					ListenPort:      hcloud.Ptr(443),
+					DestinationPort: hcloud.Ptr(8443),
+					HealthCheck: &hcloud.LoadBalancerAddServiceOptsHealthCheck{
+						Protocol: hcloud.LoadBalancerServiceProtocolTCP,
+						Port:     hcloud.Ptr(8443),
+					},
+				}
+				action = tt.fx.MockAddService(opts, tt.initialLB, nil)
+				tt.fx.ActionClient.On("WaitFor", tt.fx.Ctx, action).Return(nil)
+			},
 			perform: func(t *testing.T, tt *LBReconcilementTestCase) {
 				_, err := tt.fx.LBOps.ReconcileHCLBServices(tt.fx.Ctx, tt.initialLB, tt.service)
-				assert.Error(t, err)
+				assert.NoError(t, err)
 			},
 		},
 		{


### PR DESCRIPTION
If an unsupported port protocol is configured a warning event and log message is emitted.