### PR TITLE
fix(metrics): do not emit kubernetes_build_info metric

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -22,11 +22,9 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/component-base/metrics/legacyregistry"
-	"k8s.io/klog/v2"
-
-	// We import these in our main.go, import them here to have comparable metrics
+	// Initialize cloud-provider internal metrics (e.g. workqueue).
 	_ "k8s.io/component-base/metrics/prometheus/clientgo"
-	_ "k8s.io/component-base/metrics/prometheus/version"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -44,16 +42,6 @@ var (
 
 func init() {
 	GetRegistry().MustRegister(OperationCalled)
-
-	// metrics.SetDisabledMetric("kubernetes_build_info")
-
-	// TODO: Comment
-	GetRegistry().Unregister(prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "kubernetes_build_info",
-		},
-		[]string{},
-	))
 }
 
 func GetRegistry() prometheus.Registerer {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -23,6 +23,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
+
+	// We import these in our main.go, import them here to have comparable metrics
+	_ "k8s.io/component-base/metrics/prometheus/clientgo"
+	_ "k8s.io/component-base/metrics/prometheus/version"
 )
 
 const (
@@ -40,6 +44,16 @@ var (
 
 func init() {
 	GetRegistry().MustRegister(OperationCalled)
+
+	// metrics.SetDisabledMetric("kubernetes_build_info")
+
+	// TODO: Comment
+	GetRegistry().Unregister(prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kubernetes_build_info",
+		},
+		[]string{},
+	))
 }
 
 func GetRegistry() prometheus.Registerer {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -39,4 +39,8 @@ func TestMetrics(t *testing.T) {
 	if m := `cloud_controller_manager_operations_total{op="test"} 1`; !strings.Contains(string(body), m) {
 		t.Fatalf("no metric %s found", m)
 	}
+
+	if m := `kubernetes_build_info`; strings.Contains(string(body), m) {
+		t.Fatal("kubernetes_build_info included in our metrics", m)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -32,8 +32,6 @@ import (
 	"k8s.io/cloud-provider/options"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
-	_ "k8s.io/component-base/metrics/prometheus/clientgo"
-	_ "k8s.io/component-base/metrics/prometheus/version"
 	"k8s.io/klog/v2"
 
 	hcloud "github.com/hetznercloud/hcloud-cloud-controller-manager/hcloud"


### PR DESCRIPTION
Because `kubernetes_build_info` reports the version of the HCCM and not Kubernetes, we are removing it from the metrics registry. This happens because the intended use of `k8s.io/compeonent-base/metrics` expects us to follow the Kubernetes release cycle and versioning. As the metric is initialized in the `k8s.io/component-base/metrics/prometheus/version` package, we can just remove the import.

This was discovered through alerts being raised by the default alert rule `KubeVersionMismatch` of the `kube-prometheus-stack`.