### PR TITLE
ci: fix pre-commit golang version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,4 +56,3 @@ repos:
     hooks:
       - id: golangci-lint-full
         args: [--timeout=5m]
-        language_version: 1.23.4 # renovate: datasource=github-tags depName=golang/go

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,4 +56,4 @@ repos:
     hooks:
       - id: golangci-lint-full
         args: [--timeout=5m]
-        language_version: 1.23.4 # renovate: datasource=golang-version
+        language_version: 1.23.4 # renovate: datasource=github-tags depName=golang/go


### PR DESCRIPTION
As there was no `depName` defined with the `golang-version` `datasource`, our custom Renovate regex manager did not detect this as a dependency. We can also use the git tags from the official repository as [`golang-version`](https://docs.renovatebot.com/modules/datasource/golang-version/) is using this as a source AFAIK.

Question is, if we really need this check at all. Pre-commit will use the newest Golang version by default, which should be sufficient as `golangci-lint` will use the go version specified in the `go.mod`.