### PR TITLE
ci: fix golangci-lint using go toolchain version in pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Pull the toolchain version from go.mod
-      # setup-go feature request: https://github.com/actions/setup-go/issues/457
-      - id: toolchain-version
-        run: echo "version=$(sed -ne '/^toolchain /s/^toolchain go//p' go.mod)" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ steps.toolchain-version.outputs.version }}
-
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Pull the toolchain version from go.mod
+      # setup-go feature request: https://github.com/actions/setup-go/issues/457
+      - id: toolchain-version
+        run: echo "version=$(sed -ne '/^toolchain /s/^toolchain go//p' go.mod)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ steps.toolchain-version.outputs.version }}
+
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,4 @@ repos:
     hooks:
       - id: golangci-lint-full
         args: [--timeout=5m]
+        language_version: 1.23.7 # renovate: datasource=github-releases depName=golang/go


### PR DESCRIPTION
Fixes pre-commit CI pipeline of #881.