### PR TITLE
feat(load-balancer): enable use-private-ip annotation for Robot servers

### DIFF
--- a/docs/how-to-robot-vswitch-load-balancer.md
+++ b/docs/how-to-robot-vswitch-load-balancer.md
@@ -6,7 +6,9 @@ As a result, the annotation `load-balancer.hetzner.cloud/use-private-ip` can be 
 
 ## Configuration
 
-To configure this, enable Robot support as outlined in the [robot setup guide](./robot.md). Since the HCCM needs to fetch network data, provide the network ID using the `HCLOUD_NETWORK` environment variable. To prevent the HCCM from making other network changes, disable networking in the Helm chart and set `HCLOUD_NETWORK_ROUTES_ENABLED=false` to turn off the routes controller. Use the following snippet as a reference.
+To configure this, enable Robot support as outlined in the [robot setup guide](./robot.md). Since the HCCM needs to fetch network data, provide the network ID using the `HCLOUD_NETWORK` environment variable.
+
+To disable the Routes controller, which is incompatible with vSwitches, disable networking in the Helm chart and set `HCLOUD_NETWORK_ROUTES_ENABLED=false`. Use the following snippet as a reference.
 
 ```yaml
 networking:

--- a/docs/how-to-robot-vswitch-load-balancer.md
+++ b/docs/how-to-robot-vswitch-load-balancer.md
@@ -1,6 +1,6 @@
 # How to attach load balancers to Robot private IPs
 
-With our HCCM release v1.24.0 we introduced the option to configure InternalIPs for Robot servers. This allows creating a cluster with private networks and a mixture of Robot and Cloud servers. Using the routing feature of private networks is not supported, so it requires a CNI plugin with encapsulation methods, such as Cilium with routing mode `tunnel`. Load balancers can have targets of type IP, which can either be a public or private (vSwitch) IP of a Robot server ([API reference](https://docs.hetzner.cloud/#load-balancer-actions-add-target)).
+With the v1.24.0 release we introduced the option to configure Internal IPs for Robot servers. This allows creating a cluster with private networks and a mixture of Robot and Cloud servers. Using the routing feature of private networks is not supported, so this requires a CNI plugin with encapsulation methods, such as Cilium with routing mode `tunnel`. Load Balancers can have targets of type IP, which can either be a public or private (vSwitch) IP of a Robot server ([API reference](https://docs.hetzner.cloud/#load-balancer-actions-add-target)).
 
 As a result, the annotation `load-balancer.hetzner.cloud/use-private-ip` can be set, if the Robot server is connected to a private network and its IP is of type [InternalIP](https://kubernetes.io/docs/reference/node/node-status/#addresses).
 

--- a/docs/how-to-robot-vswitch-load-balancer.md
+++ b/docs/how-to-robot-vswitch-load-balancer.md
@@ -1,0 +1,44 @@
+# How to attach load balancers to Robot private IPs
+
+With our HCCM release v1.24.0 we introduced the option to configure InternalIPs for Robot servers. This allows creating a cluster with private networks and a mixture of Robot and Cloud servers. Using the routing feature of private networks is not supported, so it requires a CNI plugin with encapsulation methods, such as Cilium with routing mode `tunnel`. Load balancers can have targets of type IP, which can either be a public or private (vSwitch) IP of a Robot server ([API reference](https://docs.hetzner.cloud/#load-balancer-actions-add-target)).
+
+As a result, the annotation `load-balancer.hetzner.cloud/use-private-ip` can be set, if the Robot server is connected to a private network and its IP is of type [InternalIP](https://kubernetes.io/docs/reference/node/node-status/#addresses).
+
+## Configuration
+
+To configure this, enable Robot support as outlined in the [robot setup guide](./robot.md). Since the HCCM needs to fetch network data, provide the network ID using the `HCLOUD_NETWORK` environment variable. To prevent the HCCM from making other network changes, disable networking in the Helm chart and set `HCLOUD_NETWORK_ROUTES_ENABLED=false` to turn off the routes controller. Use the following snippet as a reference.
+
+```yaml
+networking:
+  enabled: false
+
+env:
+  HCLOUD_NETWORK:
+    valueFrom:
+      secretKeyRef:
+        name: hcloud
+        key: network
+
+  HCLOUD_NETWORK_ROUTES_ENABLED:
+    value: "false"
+
+  HCLOUD_TOKEN:
+    valueFrom:
+      secretKeyRef:
+        name: hcloud
+        key: token
+
+  ROBOT_USER:
+    valueFrom:
+      secretKeyRef:
+        name: hcloud
+        key: robot-user
+        optional: true
+
+  ROBOT_PASSWORD:
+    valueFrom:
+      secretKeyRef:
+        name: hcloud
+        key: robot-password
+        optional: true
+```

--- a/docs/how-to-robot-vswitch-load-balancer.md
+++ b/docs/how-to-robot-vswitch-load-balancer.md
@@ -6,7 +6,7 @@ As a result, the annotation `load-balancer.hetzner.cloud/use-private-ip` can be 
 
 ## Configuration
 
-To configure this, enable Robot support as outlined in the [robot setup guide](./robot.md). Since the HCCM needs to fetch network data, provide the network ID using the `HCLOUD_NETWORK` environment variable.
+To configure this, enable Robot support as outlined in the [Robot setup guide](./robot.md). Since the HCCM needs to fetch network data, provide the network ID using the `HCLOUD_NETWORK` environment variable.
 
 To disable the Routes controller, which is incompatible with vSwitches, disable networking in the Helm chart and set `HCLOUD_NETWORK_ROUTES_ENABLED=false`. Use the following snippet as a reference.
 

--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -664,6 +664,14 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 					svc.Name,
 					node.Name,
 				)
+				l.Recorder.Eventf(
+					svc,
+					corev1.EventTypeWarning,
+					"InternalIPNotConfigured",
+					"%s: load balancer has set `use-private-ip: true`, but no InternalIP found for node %s. Continuing with ExternalIP.",
+					op,
+					node.Name,
+				)
 			}
 
 			robotIPsToIDs[s.ServerIP] = s.ServerNumber

--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -645,6 +645,27 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 		}
 
 		for _, s := range dedicatedServers {
+			if usePrivateIP {
+				node, ok := k8sNodes[int64(s.ServerNumber)]
+				if !ok {
+					continue
+				}
+
+				internalIP := getNodeInternalIP(node)
+				if internalIP != "" {
+					robotIPsToIDs[internalIP] = s.ServerNumber
+					robotIDToIPv4[s.ServerNumber] = internalIP
+					continue
+				}
+
+				klog.Warningf(
+					"%s: load balancer %s has set `use-private-ip: true`, but no InternalIP found for node %s. Continuing with ExternalIP.",
+					op,
+					svc.Name,
+					node.Name,
+				)
+			}
+
 			robotIPsToIDs[s.ServerIP] = s.ServerNumber
 			robotIDToIPv4[s.ServerNumber] = s.ServerIP
 		}
@@ -1385,4 +1406,13 @@ func lbAttached(lb *hcloud.LoadBalancer, nwID int64, privateIPv4 string) bool {
 		}
 	}
 	return false
+}
+
+func getNodeInternalIP(node *corev1.Node) string {
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeInternalIP {
+			return addr.Address
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
This feature enables the annotation `load-balancer.hetzner.cloud/use-private-ip` for clusters that include Robot servers.

We recently introduced forwarding configured InternalIPs of Robot nodes (#865). With this addition we can use these IPs and configure them as load balancer targets, when `load-balancer.hetzner.cloud/use-private-ip` is set.