### PR TITLE
fix(load-balancer): don't print entire node object when adding robot target

### DIFF
--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -789,7 +789,7 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 				continue
 			}
 
-			klog.InfoS("add target", "op", op, "service", svc.ObjectMeta.Name, "targetName", node, "ip", ip)
+			klog.InfoS("add target (robot node)", "op", op, "service", svc.ObjectMeta.Name, "targetName", node.Name, "ip", ip)
 			opts := hcloud.LoadBalancerAddIPTargetOpts{
 				IP: net.ParseIP(ip),
 			}


### PR DESCRIPTION
When adding new targets to a loadbalancer, hcloud-cloud-controller-manager usually prints something along the lines of `"add target" op="hcops/LoadBalancerOps.ReconcileHCLBTargets" service="<service_name>" targetName="<node_name>"`. When adding robot nodes, it instead prints `"add target" op="hcops/LoadBalancerOps.ReconcileHCLBTargets" service="<service_name>" targetName="<the entire serialized node object>"` which is quite obviously wrong. This PR fixes so that it is only the name that is printed.

I also changed to log message to communicate that this it is a robot node that is being added. How this should be communicated is a matter of taste, so just let me know if you want it displayed in another way (or not at all).