### PR TITLE
test: fix waiting for an HTTP service to be available in an HTTPS test

### DIFF
--- a/tests/e2e/cloud_test.go
+++ b/tests/e2e/cloud_test.go
@@ -110,7 +110,7 @@ func TestServiceLoadBalancersHTTPS(t *testing.T) {
 
 	lbSvc, err := lbTest.CreateService(lbSvc)
 	if assert.NoError(t, err, "deploying test svc") {
-		WaitForHTTPAvailable(t, lbSvc.Status.LoadBalancer.Ingress[0].IP, false)
+		WaitForHTTPAvailable(t, lbSvc.Status.LoadBalancer.Ingress[0].IP, true)
 	}
 
 	lbTest.TearDown()


### PR DESCRIPTION
In #928 a boolean got flipped. Probably a copy-paste error.

This caused the test to wait for an HTTP service to be available in an HTTPS test.