### PR TITLE
fix: revert "fix: wrong version logged on startup (#729)"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,6 @@ builds:
       - -s
       - -w
       - -X github.com/hetznercloud/hcloud-cloud-controller-manager/hcloud.providerVersion={{ if not .IsSnapshot }}v{{ end }}{{ .Version }}
-      - -X k8s.io/component-base/version.gitVersion={{ if not .IsSnapshot }}v{{ end }}{{ .Version }}
 
 dockers:
   - build_flag_templates: [--platform=linux/amd64]


### PR DESCRIPTION
`k8s.io/component-base/version` provides a standardized way for Kubernetes components to embed and expose their version information. Currently, our build scripts overwrite the upstream version (e.g v1.32, v1.33) with the current HCCM version (e.g v1.26, v1.27). This was done to correct a log message from `k8s.io/cloud-provider`, which reported `Version v0.0.0-master+$Format:%H$`

Our feature gate `CloudControllerManagerWatchBasedRoutesReconciliation`, which is currently tested in HCCM `v1.27.0-alpha.0`, requires Kubernetes >= v1.33. This is currently broken, as the `k8s.io` libraries will report, that the current Kubernetes version is to low.

This reverts commit 6b8cbf4f4c0e2a8e7a98bd7c8346b958e638ba57.

Using `fix` to trigger a new patch release.