### PR TITLE
feat: per-port protocol and certificates

### DIFF
--- a/internal/annotation/load_balancer.go
+++ b/internal/annotation/load_balancer.go
@@ -54,6 +54,11 @@ const (
 	// values: tcp, http, https
 	LBSvcProtocol Name = "load-balancer.hetzner.cloud/protocol"
 
+	// LBSvcProtocolPorts specifies the protocol per port for the service. This allows
+	// different ports to use different protocols. Format: "80:http,443:https,9000:tcp"
+	// If set, this takes precedence over LBSvcProtocol for the specified ports.
+	LBSvcProtocolPorts Name = "load-balancer.hetzner.cloud/protocol-ports"
+
 	// LBAlgorithmType specifies the algorithm type of the Load Balancer.
 	//
 	// Possible values: round_robin, least_connections
@@ -128,6 +133,13 @@ const (
 	//
 	// HTTPS only.
 	LBSvcHTTPCertificates Name = "load-balancer.hetzner.cloud/http-certificates"
+
+	// LBSvcHTTPCertificatesPorts specifies certificates per port for HTTPS services.
+	// Format: "443:cert1,cert2;8443:cert3,cert4"
+	// If set, this takes precedence over LBSvcHTTPCertificates for the specified ports.
+	// 
+	// HTTPS only.
+	LBSvcHTTPCertificatesPorts Name = "load-balancer.hetzner.cloud/http-certificates-ports"
 
 	// LBSvcHTTPManagedCertificateName contains the names of the managed
 	// certificate to create by the Cloud Controller manager. Ignored if

--- a/internal/annotation/per_port_test.go
+++ b/internal/annotation/per_port_test.go
@@ -1,0 +1,220 @@
+package annotation
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestName_ProtocolPortsFromService(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotation  string
+		expected    map[int]hcloud.LoadBalancerServiceProtocol
+		expectError bool
+	}{
+		{
+			name:        "valid protocol ports",
+			annotation:  "80:http,443:https,9000:tcp",
+			expected: map[int]hcloud.LoadBalancerServiceProtocol{
+				80:   hcloud.LoadBalancerServiceProtocolHTTP,
+				443:  hcloud.LoadBalancerServiceProtocolHTTPS,
+				9000: hcloud.LoadBalancerServiceProtocolTCP,
+			},
+		},
+		{
+			name:        "single protocol port",
+			annotation:  "80:http",
+			expected: map[int]hcloud.LoadBalancerServiceProtocol{
+				80: hcloud.LoadBalancerServiceProtocolHTTP,
+			},
+		},
+		{
+			name:        "empty annotation",
+			annotation:  "",
+			expected:    map[int]hcloud.LoadBalancerServiceProtocol{},
+		},
+		{
+			name:        "invalid format - missing colon",
+			annotation:  "80http",
+			expectError: true,
+		},
+		{
+			name:        "invalid format - invalid port",
+			annotation:  "abc:http",
+			expectError: true,
+		},
+		{
+			name:        "invalid format - invalid protocol",
+			annotation:  "80:invalid",
+			expectError: true,
+		},
+		{
+			name:        "whitespace handling",
+			annotation:  " 80 : http , 443 : https ",
+			expected: map[int]hcloud.LoadBalancerServiceProtocol{
+				80:  hcloud.LoadBalancerServiceProtocolHTTP,
+				443: hcloud.LoadBalancerServiceProtocolHTTPS,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						string(LBSvcProtocolPorts): tt.annotation,
+					},
+				},
+			}
+
+			result, err := LBSvcProtocolPorts.ProtocolPortsFromService(svc)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestName_ProtocolPortsFromService_NoAnnotation(t *testing.T) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{},
+		},
+	}
+
+	result, err := LBSvcProtocolPorts.ProtocolPortsFromService(svc)
+
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestName_CertificatePortsFromService(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotation  string
+		expected    map[int][]*hcloud.Certificate
+		expectError bool
+	}{
+		{
+			name:       "valid certificate ports",
+			annotation: "443:cert1,cert2;8443:cert3",
+			expected: map[int][]*hcloud.Certificate{
+				443: {
+					{Name: "cert1"},
+					{Name: "cert2"},
+				},
+				8443: {
+					{Name: "cert3"},
+				},
+			},
+		},
+		{
+			name:       "single certificate port",
+			annotation: "443:cert1",
+			expected: map[int][]*hcloud.Certificate{
+				443: {
+					{Name: "cert1"},
+				},
+			},
+		},
+		{
+			name:       "certificate IDs",
+			annotation: "443:123,456",
+			expected: map[int][]*hcloud.Certificate{
+				443: {
+					{ID: 123},
+					{ID: 456},
+				},
+			},
+		},
+		{
+			name:       "mixed names and IDs",
+			annotation: "443:cert1,123",
+			expected: map[int][]*hcloud.Certificate{
+				443: {
+					{Name: "cert1"},
+					{ID: 123},
+				},
+			},
+		},
+		{
+			name:        "empty annotation",
+			annotation:  "",
+			expected:    map[int][]*hcloud.Certificate{},
+		},
+		{
+			name:        "invalid format - missing colon",
+			annotation:  "443cert1",
+			expectError: true,
+		},
+		{
+			name:        "invalid format - invalid port",
+			annotation:  "abc:cert1",
+			expectError: true,
+		},
+		{
+			name:        "invalid format - empty certificate",
+			annotation:  "443:cert1,,cert2",
+			expectError: true,
+		},
+		{
+			name:       "whitespace handling",
+			annotation: " 443 : cert1 , cert2 ; 8443 : cert3 ",
+			expected: map[int][]*hcloud.Certificate{
+				443: {
+					{Name: "cert1"},
+					{Name: "cert2"},
+				},
+				8443: {
+					{Name: "cert3"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						string(LBSvcHTTPCertificatesPorts): tt.annotation,
+					},
+				},
+			}
+
+			result, err := LBSvcHTTPCertificatesPorts.CertificatePortsFromService(svc)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestName_CertificatePortsFromService_NoAnnotation(t *testing.T) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{},
+		},
+	}
+
+	result, err := LBSvcHTTPCertificatesPorts.CertificatePortsFromService(svc)
+
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+}

--- a/internal/hcops/load_balancer_per_port_test.go
+++ b/internal/hcops/load_balancer_per_port_test.go
@@ -1,0 +1,131 @@
+package hcops
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/annotation"
+	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/mocks"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+func TestRealWorldPerPortConfiguration(t *testing.T) {
+	certClient := &mocks.CertificateClient{}
+	certClient.Test(t)
+
+	// Set up mock expectations for certificates
+	certClient.
+		On("Get", mock.Anything, "web-cert").
+		Return(&hcloud.Certificate{ID: 1, Name: "web-cert"}, nil, nil)
+	certClient.
+		On("Get", mock.Anything, "api-cert").
+		Return(&hcloud.Certificate{ID: 2, Name: "api-cert"}, nil, nil)
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-service",
+			Namespace: "default",
+			UID:       types.UID("test-uid"),
+			Annotations: map[string]string{
+				string(annotation.LBSvcProtocol):               "tcp",
+				string(annotation.LBSvcProtocolPorts):         "80:http,443:https,9000:tcp",
+				string(annotation.LBSvcHTTPCertificatesPorts): "443:web-cert,api-cert",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "http",
+					Port:     80,
+					NodePort: 32080,
+				},
+				{
+					Name:     "https",
+					Port:     443,
+					NodePort: 32443,
+				},
+				{
+					Name:     "tcp",
+					Port:     9000,
+					NodePort: 32900,
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name                string
+		port                corev1.ServicePort
+		expectedProtocol    hcloud.LoadBalancerServiceProtocol
+		expectedCertificates []*hcloud.Certificate
+	}{
+		{
+			name:             "HTTP port 80",
+			port:             service.Spec.Ports[0],
+			expectedProtocol: hcloud.LoadBalancerServiceProtocolHTTP,
+			expectedCertificates: nil,
+		},
+		{
+			name:             "HTTPS port 443 with certificates",
+			port:             service.Spec.Ports[1],
+			expectedProtocol: hcloud.LoadBalancerServiceProtocolHTTPS,
+			expectedCertificates: []*hcloud.Certificate{
+				{ID: 1}, {ID: 2},
+			},
+		},
+		{
+			name:             "TCP port 9000",
+			port:             service.Spec.Ports[2],
+			expectedProtocol: hcloud.LoadBalancerServiceProtocolTCP,
+			expectedCertificates: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := &hclbServiceOptsBuilder{
+				Port:    tc.port,
+				Service: service,
+				CertOps: &CertificateOps{CertClient: certClient},
+			}
+
+			addOpts, err := builder.buildAddServiceOpts()
+			assert.NoError(t, err)
+
+			// Verify protocol
+			assert.Equal(t, tc.expectedProtocol, addOpts.Protocol)
+
+			// Verify certificates
+			if tc.expectedCertificates != nil {
+				assert.NotNil(t, addOpts.HTTP)
+				assert.Equal(t, tc.expectedCertificates, addOpts.HTTP.Certificates)
+			} else {
+				if addOpts.HTTP != nil {
+					assert.Nil(t, addOpts.HTTP.Certificates)
+				}
+			}
+
+			updateOpts, err := builder.buildUpdateServiceOpts()
+			assert.NoError(t, err)
+
+			// Verify protocol
+			assert.Equal(t, tc.expectedProtocol, updateOpts.Protocol)
+
+			// Verify certificates
+			if tc.expectedCertificates != nil {
+				assert.NotNil(t, updateOpts.HTTP)
+				assert.Equal(t, tc.expectedCertificates, updateOpts.HTTP.Certificates)
+			} else {
+				if updateOpts.HTTP != nil {
+					assert.Nil(t, updateOpts.HTTP.Certificates)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR implements #984 

This change introduces two annotations:
- `load-balancer.hetzner.cloud/protocol-ports` allows specifying a mapping of ports to their respective protocol
- `load-balancer.hetzner.cloud/http-certificates-ports` allows specifying a mapping of ports to one or more certificates

This PR is in a draft state as the certificates part currently returns a 422 from the Hetzner API. I have an open ticket with the loadbalancer team about this. I can replicate this behaviour through the UI.