### PR TITLE
feat(helm): support NetworkPolicy

### DIFF
--- a/chart/templates/networkpolicy.yaml
+++ b/chart/templates/networkpolicy.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "hcloud-cloud-controller-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "hcloud-cloud-controller-manager.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+  - Egress
+  {{- with .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.networkPolicy.egress }}
+  egress:
+    {{- toYaml . | nindent 2 }}
+  {{- else }}
+  egress:
+  - {} # Allow all egress traffic by default
+  {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -159,3 +159,49 @@ extraVolumes: []
 #   - name: token-volume
 #     secret:
 #       secretName: hcloud-token
+
+# NetworkPolicy for the hcloud-cloud-controller-manager Pod.
+networkPolicy:
+  enabled: false
+  ingress:
+    # Metrics
+    - ports:
+      - port: 8233
+        protocol: TCP
+  egress:
+    # Hetzner API
+    - ports:
+      - port: 80
+        protocol: TCP
+      - port: 443
+        protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 213.239.246.73/32 # api.hetzner.cloud
+    # DNS
+    - ports:
+      - port: 53
+        protocol: UDP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+    # Kubernetes API
+    ## ClusterAPI
+    - ports:
+      - port: 6443
+        protocol: TCP
+      to:
+        ## ClusterAPI
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              component: kube-apiserver
+        ## K3s
+        - ipBlock:         
+            cidr: 10.0.0.0/24 # Your k3s cluster network. Use `kubectl get endpoints --namespace default kubernetes`


### PR DESCRIPTION
Add support for NetworkPolicy creation. Default to disabled.

This would be useful for cluster which do deny ingress or egress by default.
