### PR TITLE
docs(helm): extra environment variables format

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -29,7 +29,12 @@ kind: Deployment
 # change replicaCount (only used when kind is "Deployment")
 replicaCount: 1
 
-# hccm environment variables
+# You can define extra environment variables for the HCCM.
+# Both Kubernetes formats are supported: `value` and `valueFrom`.
+# Note: `valueFrom` can reference ConfigMaps, Secrets, or other supported sources.
+# Examples:
+# - ConfigMaps: https://kubernetes.io/docs/concepts/configuration/configmap/#using-configmaps-as-environment-variables
+# - Secrets: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables
 env:
   # The following variables are managed by the chart and should *not* be set here:
   # HCLOUD_METRICS_ENABLED - see monitoring.enabled

--- a/docs/reference/helm/extra-envs.md
+++ b/docs/reference/helm/extra-envs.md
@@ -1,6 +1,6 @@
 # Helm - Extra Environment Variables
 
-Extra environment variables can be set via the `env` Helm value. The well-known Kubernetes formats `value` and `valueFrom` are supported.
+You can define extra environment variables for the HCCM. Both Kubernetes formats are supported: `value` and `valueFrom`. The `valueFrom` field can reference multiple sources such as ConfigMaps and Secrets, but also supports other options. For more details, see the Kubernetes documentation on [ConfigMaps](https://kubernetes.io/docs/concepts/configuration/configmap/#using-configmaps-as-environment-variables) and [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables).
 
 ```yaml
 env:


### PR DESCRIPTION
Be more precise in the values documentation about how to set extra environment variables. Update existing docs with upstream references to most common usages.

Fixes #951