### PR TITLE
fix: add custom clusterrole for ccm helm chart

### DIFF
--- a/chart/templates/clusterrole.yml
+++ b/chart/templates/clusterrole.yml
@@ -1,0 +1,94 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "system:{{ include "hcloud-cloud-controller-manager.name" . }}"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+{{- end }}

--- a/chart/templates/clusterrolebinding.yaml
+++ b/chart/templates/clusterrolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: "system:{{ include "hcloud-cloud-controller-manager.name" . }}"
 subjects:
   - kind: ServiceAccount
     name: {{ include "hcloud-cloud-controller-manager.name" . }}


### PR DESCRIPTION
This adds a new `ClusterRole` to the helm ccm helm chart and implements the least privilege principle for ccm rbac permissions. 

The values are mostly taken from the [aws ccm](https://github.com/kubernetes/cloud-provider-aws/blob/master/charts/aws-cloud-controller-manager/values.yaml) but I added `ConfigMap` permissions (since hcloud ccm needs them) and removed `ServiceAccount` permissions.

The following SA permissions are not strictly needed, but can be nesessary if you want to run the ccm in an none default config where each controller gets its own SA. In these none default configs the user would need to add its own `ClusterRole`.
```yaml
  - apiGroups:
      - ""
    resources:
      - serviceaccounts
    verbs:
      - create
```


Fixes #1004