### PR TITLE
refactor: rename ClusterRoleBinding

### DIFF
--- a/chart/.snapshots/default.yaml
+++ b/chart/.snapshots/default.yaml
@@ -84,7 +84,9 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: "system:hcloud-cloud-controller-manager"
+  # The prefix ":restricted" originates from removing the cluster-admin role from HCCM.
+  # Renaming the ClusterRoleBinding makes the migration easier for users.
+  name: "system:hcloud-cloud-controller-manager:restricted"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/chart/.snapshots/full.daemonset.yaml
+++ b/chart/.snapshots/full.daemonset.yaml
@@ -84,7 +84,9 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: "system:hcloud-cloud-controller-manager"
+  # The prefix ":restricted" originates from removing the cluster-admin role from HCCM.
+  # Renaming the ClusterRoleBinding makes the migration easier for users.
+  name: "system:hcloud-cloud-controller-manager:restricted"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/chart/templates/clusterrolebinding.yaml
+++ b/chart/templates/clusterrolebinding.yaml
@@ -2,7 +2,9 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: "system:{{ include "hcloud-cloud-controller-manager.name" . }}"
+  # The prefix ":restricted" originates from removing the cluster-admin role from HCCM.
+  # Renaming the ClusterRoleBinding makes the migration easier for users.
+  name: "system:{{ include "hcloud-cloud-controller-manager.name" . }}:restricted"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/ccm-networks.yaml
+++ b/deploy/ccm-networks.yaml
@@ -84,7 +84,9 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: "system:hcloud-cloud-controller-manager"
+  # The prefix ":restricted" originates from removing the cluster-admin role from HCCM.
+  # Renaming the ClusterRoleBinding makes the migration easier for users.
+  name: "system:hcloud-cloud-controller-manager:restricted"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/ccm.yaml
+++ b/deploy/ccm.yaml
@@ -84,7 +84,9 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: "system:hcloud-cloud-controller-manager"
+  # The prefix ":restricted" originates from removing the cluster-admin role from HCCM.
+  # Renaming the ClusterRoleBinding makes the migration easier for users.
+  name: "system:hcloud-cloud-controller-manager:restricted"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Keeping the same ClusterRoleBinding name causes issues when migrating to the new HCCM version, as the `roleRef` field is immutable.

By changing the ClusterRoleBindings name, the migration is seamless for Helm users. Manifest users have to perform an additional cleanup step after the `helm upgrade`.