### PR TITLE
fix: default dnsPolicy ClusterFirst

### DIFF
--- a/chart/.snapshots/default.yaml
+++ b/chart/.snapshots/default.yaml
@@ -116,7 +116,7 @@ spec:
         app.kubernetes.io/name: 'hcloud-cloud-controller-manager'
     spec:
       serviceAccountName: hcloud-cloud-controller-manager
-      dnsPolicy: Default
+      dnsPolicy: ClusterFirst
       tolerations:
         # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.
         - key: "node.cloudprovider.kubernetes.io/uninitialized"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -167,7 +167,7 @@ extraVolumes: []
 
 # Set the dns policy for the deployment.
 # See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
-dnsPolicy: Default
+dnsPolicy: ClusterFirst
 # Set the dns config for the deployment.
 # See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
 dnsConfig: {}

--- a/deploy/ccm-networks.yaml
+++ b/deploy/ccm-networks.yaml
@@ -114,7 +114,7 @@ spec:
         app: hcloud-cloud-controller-manager
     spec:
       serviceAccountName: hcloud-cloud-controller-manager
-      dnsPolicy: Default
+      dnsPolicy: ClusterFirst
       tolerations:
         # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.
         - key: "node.cloudprovider.kubernetes.io/uninitialized"

--- a/deploy/ccm.yaml
+++ b/deploy/ccm.yaml
@@ -114,7 +114,7 @@ spec:
         app: hcloud-cloud-controller-manager
     spec:
       serviceAccountName: hcloud-cloud-controller-manager
-      dnsPolicy: Default
+      dnsPolicy: ClusterFirst
       tolerations:
         # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.
         - key: "node.cloudprovider.kubernetes.io/uninitialized"


### PR DESCRIPTION
The default `dnsPolicy` should be set to `ClusterFirst`, which is the default `dnsPolicy` if not specified. This is a regression bug of #559.