### PR TITLE
deps: update dependency helm to v3.19.2 for deploy manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           setup-tools: |
             helm
-          helm: v3.19.1 # renovate: datasource=github-releases depName=helm/helm
+          helm: v3.19.2 # renovate: datasource=github-releases depName=helm/helm
 
       - uses: actions/checkout@v5
       - name: Generate manifests from helm chart


### PR DESCRIPTION
CI job had outdated Helm version. Additionally, added renovate tag