### PR TITLE
Remove "proxyProtocolEnabledDefault" because it was always false.

### DIFF
--- a/hcloud/load_balancers.go
+++ b/hcloud/load_balancers.go
@@ -32,7 +32,6 @@ type LoadBalancerOps interface {
 type loadBalancers struct {
 	lbOps                        LoadBalancerOps
 	ipv6EnabledDefault           bool
-	proxyProtocolEnabledDefault  bool
 	privateIngressEnabledDefault bool
 }
 
@@ -280,7 +279,7 @@ func (l *loadBalancers) getProxyProtocolEnabled(svc *corev1.Service) (bool, erro
 		return enable, nil
 	}
 	if errors.Is(err, annotation.ErrNotSet) {
-		return l.proxyProtocolEnabledDefault, nil
+		return false, nil
 	}
 	return false, err
 }


### PR DESCRIPTION
This variable was always false. It is an unexported variable that was only read but never written. It can be removed.