### PR TITLE
Add ROBOT_USE_LEGACY_PROVIDER_ID to use legacy provider ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ hcloud-cloud-controller-manager
 *.tgz
 hack/.*
 coverage/
+.vscode

--- a/hcloud/instances.go
+++ b/hcloud/instances.go
@@ -374,8 +374,14 @@ func (s robotServer) IsShutdown() (bool, error) {
 }
 
 func (s robotServer) Metadata(_ int64, node *corev1.Node, cfg config.HCCMConfiguration) (*cloudprovider.InstanceMetadata, error) {
+	var providerID string
+	if cfg.Robot.UseLegacyProviderID {
+		providerID = providerid.FromRobotLegacyServerNumber(s.ServerNumber)
+	} else {
+		providerID = providerid.FromRobotServerNumber(s.ServerNumber)
+	}
 	return &cloudprovider.InstanceMetadata{
-		ProviderID:    providerid.FromRobotServerNumber(s.ServerNumber),
+		ProviderID:    providerID,
 		InstanceType:  getInstanceTypeOfRobotServer(s.Server),
 		NodeAddresses: robotNodeAddresses(s.Server, node, cfg, s.recorder),
 		Zone:          getZoneOfRobotServer(s.Server),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,12 +21,13 @@ const (
 	hcloudNetwork  = "HCLOUD_NETWORK"
 	hcloudDebug    = "HCLOUD_DEBUG"
 
-	robotEnabled            = "ROBOT_ENABLED"
-	robotUser               = "ROBOT_USER"
-	robotPassword           = "ROBOT_PASSWORD"
-	robotCacheTimeout       = "ROBOT_CACHE_TIMEOUT"
-	robotRateLimitWaitTime  = "ROBOT_RATE_LIMIT_WAIT_TIME"
-	robotForwardInternalIPs = "ROBOT_FORWARD_INTERNAL_IPS"
+	robotEnabled             = "ROBOT_ENABLED"
+	robotUser                = "ROBOT_USER"
+	robotPassword            = "ROBOT_PASSWORD"
+	robotCacheTimeout        = "ROBOT_CACHE_TIMEOUT"
+	robotRateLimitWaitTime   = "ROBOT_RATE_LIMIT_WAIT_TIME"
+	robotForwardInternalIPs  = "ROBOT_FORWARD_INTERNAL_IPS"
+	robotUseLegacyProviderID = "ROBOT_USE_LEGACY_PROVIDER_ID"
 
 	hcloudInstancesAddressFamily = "HCLOUD_INSTANCES_ADDRESS_FAMILY"
 
@@ -51,7 +52,8 @@ type RobotConfiguration struct {
 	CacheTimeout      time.Duration
 	RateLimitWaitTime time.Duration
 	// ForwardInternalIPs is enabled by default.
-	ForwardInternalIPs bool
+	ForwardInternalIPs  bool
+	UseLegacyProviderID bool
 }
 
 type MetricsConfiguration struct {
@@ -156,7 +158,10 @@ func Read() (HCCMConfiguration, error) {
 	}
 	// Robot needs to be enabled
 	cfg.Robot.ForwardInternalIPs = cfg.Robot.ForwardInternalIPs && cfg.Robot.Enabled
-
+	cfg.Robot.UseLegacyProviderID, err = getEnvBool(robotUseLegacyProviderID, false)
+	if err != nil {
+		errs = append(errs, err)
+	}
 	cfg.Metrics.Enabled, err = getEnvBool(hcloudMetricsEnabled, true)
 	if err != nil {
 		errs = append(errs, err)

--- a/internal/providerid/providerid.go
+++ b/internal/providerid/providerid.go
@@ -81,3 +81,8 @@ func FromCloudServerID(serverID int64) string {
 func FromRobotServerNumber(serverNumber int) string {
 	return fmt.Sprintf("%s%d", prefixRobot, serverNumber)
 }
+
+// FromRobotLegacyServerNumber generates the canonical ProviderID for a Robot Server.
+func FromRobotLegacyServerNumber(serverNumber int) string {
+	return fmt.Sprintf("%s%d", prefixRobotLegacy, serverNumber)
+}


### PR DESCRIPTION
For some clusters it might be challenging to
update the tool creating new nodes (like
Cluster API Provider Hetzner) and the CCM so that
both agree on the provider ID format.

If the env var ROBOT_USE_LEGACY_PROVIDER_ID is set to a true value ("1", "t", "T", "true", "TRUE",
"True"), then the CCM will use the legacy format
("hcloud://bm-NNNN") when returning
InstanceMetadata.

This applies only, when the node is created. Once
a provider ID is set, it won't be changed again.