### PR TITLE
fix(load-balancer): wait for action of managed certificate

### DIFF
--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -187,7 +187,7 @@ func (c *cloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 	lbOps := &hcops.LoadBalancerOps{
 		LBClient:      &c.client.LoadBalancer,
 		RobotClient:   c.robotClient,
-		CertOps:       &hcops.CertificateOps{CertClient: &c.client.Certificate},
+		CertOps:       &hcops.CertificateOps{ActionClient: &c.client.Action, CertClient: &c.client.Certificate},
 		ActionClient:  &c.client.Action,
 		NetworkClient: &c.client.Network,
 		NetworkID:     c.networkID,

--- a/internal/hcops/load_balancer_internal_test.go
+++ b/internal/hcops/load_balancer_internal_test.go
@@ -29,7 +29,8 @@ func TestHCLBServiceOptsBuilder(t *testing.T) {
 		mock               func(t *testing.T, tt *testCase)
 
 		// Set during test setup
-		certClient *mocks.CertificateClient
+		certClient   *mocks.CertificateClient
+		actionClient *mocks.ActionClient
 	}
 
 	tests := []testCase{
@@ -429,6 +430,8 @@ func TestHCLBServiceOptsBuilder(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.certClient = &mocks.CertificateClient{}
 			tt.certClient.Test(t)
+			tt.actionClient = &mocks.ActionClient{}
+			tt.actionClient.Test(t)
 
 			if tt.mock != nil {
 				tt.mock(t, &tt)
@@ -442,7 +445,7 @@ func TestHCLBServiceOptsBuilder(t *testing.T) {
 						Annotations: map[string]string{},
 					},
 				},
-				CertOps: &CertificateOps{CertClient: tt.certClient},
+				CertOps: &CertificateOps{ActionClient: tt.actionClient, CertClient: tt.certClient},
 				cfg:     tt.cfg,
 			}
 			for k, v := range tt.serviceAnnotations {

--- a/internal/hcops/testing.go
+++ b/internal/hcops/testing.go
@@ -46,7 +46,7 @@ func NewLoadBalancerOpsFixture(t *testing.T) *LoadBalancerOpsFixture {
 
 	fx.LBOps = &LoadBalancerOps{
 		LBClient:      fx.LBClient,
-		CertOps:       &CertificateOps{CertClient: fx.CertClient},
+		CertOps:       &CertificateOps{ActionClient: fx.ActionClient, CertClient: fx.CertClient},
 		ActionClient:  fx.ActionClient,
 		NetworkClient: fx.NetworkClient,
 		RobotClient:   fx.RobotClient,


### PR DESCRIPTION
The action from creating the managed certificate was not awaited, which could cause issues where the creation fails, but this is not reported back on the Service. We now await the action and report its status back to the controller.