### PR TITLE
fix(route): error handling on locked networks

### DIFF
--- a/hcloud/routes.go
+++ b/hcloud/routes.go
@@ -9,6 +9,7 @@ import (
 
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -179,6 +180,13 @@ func (r *routes) CreateRoute(ctx context.Context, _ string, _ string, route *clo
 	}
 	action, _, err := r.client.Network.AddRoute(ctx, r.network, opts)
 	if err != nil {
+		if hcloud.IsError(err, hcloud.ErrorCodeLocked, hcloud.ErrorCodeConflict) {
+			return apierrors.NewConflict(
+				corev1.Resource("nodes"),
+				string(route.TargetNode),
+				err,
+			)
+		}
 		return fmt.Errorf("%s: %w", op, err)
 	}
 

--- a/hcloud/routes.go
+++ b/hcloud/routes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"net"
 	"time"
 
@@ -20,9 +21,16 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var (
-	serversCacheMissRefreshRate = rate.Every(30 * time.Second)
-)
+var serversCacheMissRefreshRate = rate.Every(30 * time.Second)
+
+// routeRetryDelay returns a jittered delay in [1s, 2s) for the single
+// retry we attempt on hcloud lock/conflict errors. Jitter avoids a
+// thundering herd when many concurrent route operations collide on the
+// same Network lock.
+func routeRetryDelay() time.Duration {
+	const base = 1 * time.Second
+	return base + time.Duration(rand.Int64N(int64(base))) //nolint:gosec // jitter, not security-sensitive
+}
 
 type routes struct {
 	client      *hcloud.Client
@@ -102,7 +110,7 @@ func (r *routes) ListRoutes(ctx context.Context, _ string) ([]*cloudprovider.Rou
 // CreateRoute creates the described managed route
 // route.Name will be ignored, although the cloud-provider may use nameHint
 // to create a more user-meaningful name.
-func (r *routes) CreateRoute(ctx context.Context, clusterName string, nameHint string, route *cloudprovider.Route) error {
+func (r *routes) CreateRoute(ctx context.Context, _ string, _ string, route *cloudprovider.Route) error {
 	const op = "hcloud/CreateRoute"
 	metrics.OperationCalled.WithLabelValues(op).Inc()
 
@@ -159,35 +167,50 @@ func (r *routes) CreateRoute(ctx context.Context, clusterName string, nameHint s
 		)
 	}
 
-	doesRouteAlreadyExist, err := r.checkIfRouteAlreadyExists(ctx, route)
+	routeExists, err := r.checkIfRouteAlreadyExists(ctx, route)
 	if err != nil {
 		return fmt.Errorf("%s: %w", op, err)
 	}
 
-	if !doesRouteAlreadyExist {
-		opts := hcloud.NetworkAddRouteOpts{
-			Route: hcloud.NetworkRoute{
-				Destination: cidr,
-				Gateway:     ip,
-			},
-		}
-		action, _, err := r.client.Network.AddRoute(ctx, r.network, opts)
-		if err != nil {
-			if hcloud.IsError(err, hcloud.ErrorCodeLocked, hcloud.ErrorCodeConflict) {
-				retryDelay := time.Second * 5
-				klog.InfoS("retry due to conflict or lock",
-					"op", op, "delay", fmt.Sprintf("%v", retryDelay), "err", fmt.Sprintf("%v", err))
-				time.Sleep(retryDelay)
-
-				return r.CreateRoute(ctx, clusterName, nameHint, route)
-			}
-			return fmt.Errorf("%s: %w", op, err)
-		}
-
-		if err := r.client.Action.WaitFor(ctx, action); err != nil {
-			return fmt.Errorf("%s: %w", op, err)
-		}
+	if routeExists {
+		klog.InfoS(
+			"route already exists: skipping creation",
+			"target-node", route.TargetNode,
+			"destination-cidr", route.DestinationCIDR,
+		)
+		return nil
 	}
+
+	opts := hcloud.NetworkAddRouteOpts{
+		Route: hcloud.NetworkRoute{
+			Destination: cidr,
+			Gateway:     ip,
+		},
+	}
+	action, _, err := r.client.Network.AddRoute(ctx, r.network, opts)
+	if err != nil && hcloud.IsError(err, hcloud.ErrorCodeLocked, hcloud.ErrorCodeConflict) {
+		delay := routeRetryDelay()
+		klog.InfoS(
+			"network is locked: retrying route creation",
+			"target-node", route.TargetNode,
+			"destination-cidr", route.DestinationCIDR,
+			"delay", delay,
+		)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%s: %w", op, ctx.Err())
+		case <-time.After(delay):
+		}
+		action, _, err = r.client.Network.AddRoute(ctx, r.network, opts)
+	}
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+
+	if err := r.client.Action.WaitFor(ctx, action); err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+
 	return nil
 }
 
@@ -233,15 +256,22 @@ func (r *routes) deleteRouteFromHcloud(ctx context.Context, cidr *net.IPNet, ip 
 	}
 
 	action, _, err := r.client.Network.DeleteRoute(ctx, r.network, opts)
-	if err != nil {
-		if hcloud.IsError(err, hcloud.ErrorCodeLocked, hcloud.ErrorCodeConflict) {
-			retryDelay := time.Second * 5
-			klog.InfoS("retry due to conflict or lock",
-				"op", op, "delay", fmt.Sprintf("%v", retryDelay), "err", fmt.Sprintf("%v", err))
-			time.Sleep(retryDelay)
-
-			return r.deleteRouteFromHcloud(ctx, cidr, ip)
+	if err != nil && hcloud.IsError(err, hcloud.ErrorCodeLocked, hcloud.ErrorCodeConflict) {
+		delay := routeRetryDelay()
+		klog.InfoS(
+			"network is locked: retrying route deletion",
+			"target-ip", ip,
+			"destination-cidr", cidr,
+			"delay", delay,
+		)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%s: %w", op, ctx.Err())
+		case <-time.After(delay):
 		}
+		action, _, err = r.client.Network.DeleteRoute(ctx, r.network, opts)
+	}
+	if err != nil {
 		return fmt.Errorf("%s: %w", op, err)
 	}
 	if err := r.client.Action.WaitFor(ctx, action); err != nil {

--- a/hcloud/routes.go
+++ b/hcloud/routes.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand/v2"
 	"net"
 	"time"
 
@@ -22,15 +21,6 @@ import (
 )
 
 var serversCacheMissRefreshRate = rate.Every(30 * time.Second)
-
-// routeRetryDelay returns a jittered delay in [1s, 2s) for the single
-// retry we attempt on hcloud lock/conflict errors. Jitter avoids a
-// thundering herd when many concurrent route operations collide on the
-// same Network lock.
-func routeRetryDelay() time.Duration {
-	const base = 1 * time.Second
-	return base + time.Duration(rand.Int64N(int64(base))) //nolint:gosec // jitter, not security-sensitive
-}
 
 type routes struct {
 	client      *hcloud.Client
@@ -188,21 +178,6 @@ func (r *routes) CreateRoute(ctx context.Context, _ string, _ string, route *clo
 		},
 	}
 	action, _, err := r.client.Network.AddRoute(ctx, r.network, opts)
-	if err != nil && hcloud.IsError(err, hcloud.ErrorCodeLocked, hcloud.ErrorCodeConflict) {
-		delay := routeRetryDelay()
-		klog.InfoS(
-			"network is locked: retrying route creation",
-			"target-node", route.TargetNode,
-			"destination-cidr", route.DestinationCIDR,
-			"delay", delay,
-		)
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("%s: %w", op, ctx.Err())
-		case <-time.After(delay):
-		}
-		action, _, err = r.client.Network.AddRoute(ctx, r.network, opts)
-	}
 	if err != nil {
 		return fmt.Errorf("%s: %w", op, err)
 	}
@@ -256,21 +231,6 @@ func (r *routes) deleteRouteFromHcloud(ctx context.Context, cidr *net.IPNet, ip 
 	}
 
 	action, _, err := r.client.Network.DeleteRoute(ctx, r.network, opts)
-	if err != nil && hcloud.IsError(err, hcloud.ErrorCodeLocked, hcloud.ErrorCodeConflict) {
-		delay := routeRetryDelay()
-		klog.InfoS(
-			"network is locked: retrying route deletion",
-			"target-ip", ip,
-			"destination-cidr", cidr,
-			"delay", delay,
-		)
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("%s: %w", op, ctx.Err())
-		case <-time.After(delay):
-		}
-		action, _, err = r.client.Network.DeleteRoute(ctx, r.network, opts)
-	}
 	if err != nil {
 		return fmt.Errorf("%s: %w", op, err)
 	}

--- a/hcloud/routes.go
+++ b/hcloud/routes.go
@@ -130,10 +130,10 @@ func (r *routes) CreateRoute(ctx context.Context, _ string, _ string, route *clo
 		return fmt.Errorf("%s: %w", op, err)
 	}
 
-	clusterNetSize, _ := r.clusterCIDR.Mask.Size()
-	destNetSize, _ := cidr.Mask.Size()
+	clusterPrefixLen, _ := r.clusterCIDR.Mask.Size()
+	destPrefixLen, _ := cidr.Mask.Size()
 
-	if !r.clusterCIDR.Contains(cidr.IP) || destNetSize < clusterNetSize {
+	if !r.clusterCIDR.Contains(cidr.IP) || destPrefixLen < clusterPrefixLen {
 		node := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      string(route.TargetNode),

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -22,8 +22,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/component-base/metrics/legacyregistry"
-	// Initialize cloud-provider internal metrics (e.g. workqueue).
-	_ "k8s.io/component-base/metrics/prometheus/clientgo"
+	_ "k8s.io/component-base/metrics/prometheus/clientgo" // Initialize cloud-provider internal metrics (e.g. workqueue).
 	"k8s.io/klog/v2"
 )
 


### PR DESCRIPTION
If an error code `conflict` or `locked` is returned when adding a new route, the retry mechanism of HCCM sleeps the current goroutine for five seconds and calls the `CreateRoute` method recursively, without a max retry counter.

This behavior is inefficient and prone to error. Additionally, the `k8s.io/cloud-provider` library already performs retry handling on errors. Doing this twice might result in a fast rate-limit exhaustion.

I propose to remove retry handling from our side and let `k8s.io/cloud-provider` handle this.
