### PR TITLE
test: address e2e test flakiness

### DIFF
--- a/tests/e2e/cloud_test.go
+++ b/tests/e2e/cloud_test.go
@@ -73,7 +73,7 @@ func TestServiceLoadBalancersMinimalSetup(t *testing.T) {
 		string(annotation.LBLocation): "nbg1",
 	})
 
-	lbSvc, err = lbTest.CreateService(lbSvc)
+	lbSvc, err = lbTest.CreateService(lbSvc, 6*time.Minute)
 	require.NoError(t, err)
 
 	err = lbTest.WaitForHTTPAvailable(lbSvc.Status.LoadBalancer.Ingress[0].IP, false)
@@ -102,7 +102,7 @@ func TestServiceLoadBalancersHTTPS(t *testing.T) {
 		string(annotation.LBSvcProtocol):         "https",
 	})
 
-	lbSvc, err = lbTest.CreateService(lbSvc)
+	lbSvc, err = lbTest.CreateService(lbSvc, 6*time.Minute)
 	require.NoError(t, err)
 
 	err = lbTest.WaitForHTTPAvailable(lbSvc.Status.LoadBalancer.Ingress[0].IP, true)
@@ -135,7 +135,7 @@ func TestServiceLoadBalancersHTTPSWithManagedCertificate(t *testing.T) {
 		string(annotation.LBSvcHTTPManagedCertificateUseACMEStaging): "true",
 	})
 
-	lbSvc, err = lbTest.CreateService(lbSvc)
+	lbSvc, err = lbTest.CreateService(lbSvc, 16*time.Minute)
 	require.NoError(t, err)
 
 	certs, err := testCluster.hcloud.Certificate.AllWithOpts(t.Context(), hcloud.CertificateListOpts{
@@ -171,7 +171,7 @@ func TestServiceLoadBalancersWithPrivateNetwork(t *testing.T) {
 		string(annotation.PrivateSubnetIPRange): ipRange.String(),
 	})
 
-	lbSvc, err = lbTest.CreateService(lbSvc)
+	lbSvc, err = lbTest.CreateService(lbSvc, 8*time.Minute)
 	require.NoError(t, err)
 
 	err = lbTest.WaitForHTTPAvailable(lbSvc.Status.LoadBalancer.Ingress[0].IP, false)

--- a/tests/e2e/cloud_test.go
+++ b/tests/e2e/cloud_test.go
@@ -73,7 +73,7 @@ func TestServiceLoadBalancersMinimalSetup(t *testing.T) {
 		string(annotation.LBLocation): "nbg1",
 	})
 
-	lbSvc, err = lbTest.CreateService(lbSvc, 6*time.Minute)
+	lbSvc, err = lbTest.CreateService(lbSvc)
 	require.NoError(t, err)
 
 	err = lbTest.WaitForHTTPAvailable(lbSvc.Status.LoadBalancer.Ingress[0].IP, false)
@@ -102,7 +102,7 @@ func TestServiceLoadBalancersHTTPS(t *testing.T) {
 		string(annotation.LBSvcProtocol):         "https",
 	})
 
-	lbSvc, err = lbTest.CreateService(lbSvc, 6*time.Minute)
+	lbSvc, err = lbTest.CreateService(lbSvc)
 	require.NoError(t, err)
 
 	err = lbTest.WaitForHTTPAvailable(lbSvc.Status.LoadBalancer.Ingress[0].IP, true)
@@ -135,7 +135,7 @@ func TestServiceLoadBalancersHTTPSWithManagedCertificate(t *testing.T) {
 		string(annotation.LBSvcHTTPManagedCertificateUseACMEStaging): "true",
 	})
 
-	lbSvc, err = lbTest.CreateService(lbSvc, 16*time.Minute)
+	lbSvc, err = lbTest.CreateService(lbSvc)
 	require.NoError(t, err)
 
 	certs, err := testCluster.hcloud.Certificate.AllWithOpts(t.Context(), hcloud.CertificateListOpts{
@@ -171,7 +171,7 @@ func TestServiceLoadBalancersWithPrivateNetwork(t *testing.T) {
 		string(annotation.PrivateSubnetIPRange): ipRange.String(),
 	})
 
-	lbSvc, err = lbTest.CreateService(lbSvc, 8*time.Minute)
+	lbSvc, err = lbTest.CreateService(lbSvc)
 	require.NoError(t, err)
 
 	err = lbTest.WaitForHTTPAvailable(lbSvc.Status.LoadBalancer.Ingress[0].IP, false)

--- a/tests/e2e/cloud_test.go
+++ b/tests/e2e/cloud_test.go
@@ -81,8 +81,6 @@ func TestServiceLoadBalancersMinimalSetup(t *testing.T) {
 }
 
 func TestServiceLoadBalancersHTTPS(t *testing.T) {
-	t.Parallel()
-
 	lbTest := lbTestHelper{
 		t:       t,
 		podName: "loadbalancer-https",
@@ -112,8 +110,6 @@ func TestServiceLoadBalancersHTTPS(t *testing.T) {
 }
 
 func TestServiceLoadBalancersHTTPSWithManagedCertificate(t *testing.T) {
-	t.Parallel()
-
 	if testCluster.certDomain == "" {
 		t.Skip("Skipping because CERT_DOMAIN is not set")
 	}

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	hrobot "github.com/syself/hrobot-go"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -331,7 +330,8 @@ func (l *lbTestHelper) TearDown() {
 		}
 		return k8serrors.IsNotFound(err), nil
 	})
-	require.NoError(l.t, err)
+	// The cluster is deleted afterward, so we can info log this error
+	l.t.Logf("error tearing down test namespace: %w", err)
 }
 
 // WaitForHTTPAvailable tries to connect to the given IP via HTTP or HTTPS

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -289,7 +289,7 @@ func (l *lbTestHelper) CreateService(lbSvc *corev1.Service) (*corev1.Service, er
 		return nil, fmt.Errorf("could not create service: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(l.t.Context(), 4*time.Minute)
+	ctx, cancel := context.WithTimeout(l.t.Context(), 6*time.Minute)
 	defer cancel()
 
 	retries := 0

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -150,6 +150,7 @@ func (tc *TestCluster) Stop() error {
 		return fmt.Errorf("fetching load balancers via selector %s: %w", selector, err)
 	}
 	for _, lb := range lbs {
+		// Stop is called after `m.Run()`, so we can't use t.Log anymore.
 		fmt.Printf("force-deleting leaked load balancer %d (%s)\n", lb.ID, lb.Name)
 		if _, err := tc.hcloud.LoadBalancer.Delete(ctx, lb); err != nil {
 			errs = append(errs, fmt.Errorf("delete leaked load balancer %d failed: %w", lb.ID, err))
@@ -157,6 +158,7 @@ func (tc *TestCluster) Stop() error {
 	}
 
 	for _, item := range tc.certificates.All() {
+		// Stop is called after `m.Run()`, so we can't use t.Log anymore.
 		fmt.Printf("deleting certificate %d\n", item)
 		if _, err := tc.hcloud.Certificate.Delete(ctx, &hcloud.Certificate{ID: item}); err != nil {
 			errs = append(errs, fmt.Errorf("delete certificate %d failed: %w", item, err))

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -292,7 +292,7 @@ func (l *lbTestHelper) ServiceDefinition(pod *corev1.Pod, annotations map[string
 
 // CreateService creates a k8s service based on the given service definition
 // and waits until it is "ready".
-func (l *lbTestHelper) CreateService(lbSvc *corev1.Service) (*corev1.Service, error) {
+func (l *lbTestHelper) CreateService(lbSvc *corev1.Service, timeout time.Duration) (*corev1.Service, error) {
 	l.t.Helper()
 
 	lbSvc, err := testCluster.k8sClient.CoreV1().Services(l.namespace).Create(l.t.Context(), lbSvc, metav1.CreateOptions{})
@@ -302,7 +302,7 @@ func (l *lbTestHelper) CreateService(lbSvc *corev1.Service) (*corev1.Service, er
 
 	testCluster.loadBalancers.Add(string(lbSvc.UID))
 
-	ctx, cancel := context.WithTimeout(l.t.Context(), 8*time.Minute)
+	ctx, cancel := context.WithTimeout(l.t.Context(), timeout)
 	defer cancel()
 
 	retries := 0

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -331,7 +331,7 @@ func (l *lbTestHelper) TearDown() {
 		return k8serrors.IsNotFound(err), nil
 	})
 	// The cluster is deleted afterward, so we can info log this error
-	l.t.Logf("error tearing down test namespace: %w", err)
+	l.t.Logf("error tearing down test namespace: %v", err)
 }
 
 // WaitForHTTPAvailable tries to connect to the given IP via HTTP or HTTPS

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -330,8 +330,10 @@ func (l *lbTestHelper) TearDown() {
 		}
 		return k8serrors.IsNotFound(err), nil
 	})
-	// The cluster is deleted afterward, so we can info log this error
-	l.t.Logf("error tearing down test namespace: %v", err)
+	if err != nil {
+		// The cluster is deleted afterward, so we can info log this error
+		l.t.Logf("error tearing down test namespace: %v", err)
+	}
 }
 
 // WaitForHTTPAvailable tries to connect to the given IP via HTTP or HTTPS

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -228,7 +228,7 @@ func (l *lbTestHelper) DeployTestPod() (*corev1.Pod, error) {
 		return nil, fmt.Errorf("could not create test pod: %w", err)
 	}
 
-	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 2*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		p, err := testCluster.k8sClient.CoreV1().Pods(l.namespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -242,7 +242,7 @@ func (l *lbTestHelper) DeployTestPod() (*corev1.Pod, error) {
 		return false, nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("pod %s did not come up after 1 minute: %w", podName, err)
+		return nil, fmt.Errorf("pod %s did not come up after 2 minutes: %w", podName, err)
 	}
 
 	return pod, nil
@@ -288,7 +288,7 @@ func (l *lbTestHelper) CreateService(lbSvc *corev1.Service) (*corev1.Service, er
 		return nil, fmt.Errorf("could not create service: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(l.t.Context(), 6*time.Minute)
+	ctx, cancel := context.WithTimeout(l.t.Context(), 8*time.Minute)
 	defer cancel()
 
 	retries := 0
@@ -323,7 +323,9 @@ func (l *lbTestHelper) TearDown() {
 
 	// Use context.Background() rather than t.Context(): cleanup must run to
 	// completion even when the test has already been cancelled or failed.
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+	ctx := context.Background()
+
+	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
 		err := testCluster.k8sClient.CoreV1().Namespaces().Delete(ctx, l.namespace, metav1.DeleteOptions{})
 		if err != nil && !k8serrors.IsNotFound(err) {
 			return false, err
@@ -338,7 +340,7 @@ func (l *lbTestHelper) TearDown() {
 
 // WaitForHTTPAvailable tries to connect to the given IP via HTTP or HTTPS
 // (controlled by useHTTPS). It uses exponential backoff starting at 1s and
-// capping at 30s, waiting up to 6 minutes for a successful HTTP 200 response.
+// capping at 30s, waiting up to 8 minutes for a successful HTTP 200 response.
 // Each individual request has a 5s timeout.
 func (l *lbTestHelper) WaitForHTTPAvailable(ingressIP string, useHTTPS bool) error {
 	l.t.Helper()
@@ -356,7 +358,7 @@ func (l *lbTestHelper) WaitForHTTPAvailable(ingressIP string, useHTTPS bool) err
 		proto = "https"
 	}
 
-	ctx, cancel := context.WithTimeout(l.t.Context(), 6*time.Minute)
+	ctx, cancel := context.WithTimeout(l.t.Context(), 8*time.Minute)
 	defer cancel()
 
 	retries := 0
@@ -378,7 +380,7 @@ func (l *lbTestHelper) WaitForHTTPAvailable(ingressIP string, useHTTPS bool) err
 
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("timed out after 6m waiting for %s to be available", ingressIP)
+			return fmt.Errorf("timed out after 8m waiting for %s to be available", ingressIP)
 		case <-time.After(pollBackoff(retries)):
 			retries++
 		}

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/hcops"
 	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/testsupport"
 	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/utils"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
@@ -52,7 +54,7 @@ type TestCluster struct {
 	certDomain string
 
 	certificates  *utils.SyncSet[int64]
-	loadBalancers *utils.SyncSet[int64]
+	loadBalancers *utils.SyncSet[string]
 }
 
 func (tc *TestCluster) Start() error {
@@ -103,7 +105,7 @@ func (tc *TestCluster) Start() error {
 	tc.certDomain = os.Getenv("CERT_DOMAIN")
 
 	tc.certificates = utils.NewSyncSet[int64]()
-	tc.loadBalancers = utils.NewSyncSet[int64]()
+	tc.loadBalancers = utils.NewSyncSet[string]()
 
 	return nil
 }
@@ -112,10 +114,20 @@ func (tc *TestCluster) Stop() error {
 	errs := make([]error, 0, tc.loadBalancers.Size()+tc.certificates.Size())
 	ctx := context.Background()
 
-	for _, item := range tc.loadBalancers.All() {
-		fmt.Printf("deleting load balancer %d\n", item)
-		if _, err := tc.hcloud.LoadBalancer.Delete(ctx, &hcloud.LoadBalancer{ID: item}); err != nil {
-			errs = append(errs, fmt.Errorf("delete load balancer %d failed: %w", item, err))
+	uids := tc.loadBalancers.All()
+	selector := fmt.Sprintf("%s in (%s)", hcops.LabelServiceUID, strings.Join(uids, ","))
+	lbs, err := tc.hcloud.LoadBalancer.AllWithOpts(ctx, hcloud.LoadBalancerListOpts{
+		ListOpts: hcloud.ListOpts{
+			LabelSelector: selector,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("fetching load balancers via selector %s: %w", selector, err)
+	}
+	for _, lb := range lbs {
+		fmt.Printf("force-deleting leaked load balancer %d (%s)\n", lb.ID, lb.Name)
+		if _, err := tc.hcloud.LoadBalancer.Delete(ctx, lb); err != nil {
+			errs = append(errs, fmt.Errorf("delete leaked load balancer %d failed: %w", lb.ID, err))
 		}
 	}
 
@@ -287,6 +299,8 @@ func (l *lbTestHelper) CreateService(lbSvc *corev1.Service) (*corev1.Service, er
 	if err != nil {
 		return nil, fmt.Errorf("could not create service: %w", err)
 	}
+
+	testCluster.loadBalancers.Add(string(lbSvc.UID))
 
 	ctx, cancel := context.WithTimeout(l.t.Context(), 8*time.Minute)
 	defer cancel()

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -24,11 +24,36 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/annotation"
 	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/hcops"
 	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/testsupport"
 	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/utils"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
+
+// Load Balancer creation timeouts. Services that involve certificate
+// provisioning take longer to become ready.
+const (
+	lbCreateTimeoutDefault = 8 * time.Minute
+	lbCreateTimeoutCert    = 16 * time.Minute
+)
+
+// lbCreateTimeoutFor returns the timeout to use when waiting for the given
+// Load Balancer service to become ready.
+func lbCreateTimeoutFor(svc *corev1.Service) time.Duration {
+	certAnnotations := []annotation.Name{
+		annotation.LBSvcHTTPCertificates,
+		annotation.LBSvcHTTPCertificateType,
+		annotation.LBSvcHTTPManagedCertificateName,
+		annotation.LBSvcHTTPManagedCertificateDomains,
+	}
+	for _, a := range certAnnotations {
+		if _, ok := svc.Annotations[string(a)]; ok {
+			return lbCreateTimeoutCert
+		}
+	}
+	return lbCreateTimeoutDefault
+}
 
 var rng *rand.Rand
 
@@ -291,9 +316,12 @@ func (l *lbTestHelper) ServiceDefinition(pod *corev1.Pod, annotations map[string
 }
 
 // CreateService creates a k8s service based on the given service definition
-// and waits until it is "ready".
-func (l *lbTestHelper) CreateService(lbSvc *corev1.Service, timeout time.Duration) (*corev1.Service, error) {
+// and waits until it is "ready". The wait timeout is derived from the service
+// annotations: services that provision certificates get a longer timeout.
+func (l *lbTestHelper) CreateService(lbSvc *corev1.Service) (*corev1.Service, error) {
 	l.t.Helper()
+
+	timeout := lbCreateTimeoutFor(lbSvc)
 
 	lbSvc, err := testCluster.k8sClient.CoreV1().Services(l.namespace).Create(l.t.Context(), lbSvc, metav1.CreateOptions{})
 	if err != nil {

--- a/tests/e2e/robot_test.go
+++ b/tests/e2e/robot_test.go
@@ -4,7 +4,6 @@ package e2e
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -88,7 +87,7 @@ func TestServiceLoadBalancersRobot(t *testing.T) {
 		string(annotation.LBNodeSelector): "instance.hetzner.cloud/is-root-server=true",
 	})
 
-	lbSvc, err = lbTest.CreateService(lbSvc, 8*time.Minute)
+	lbSvc, err = lbTest.CreateService(lbSvc)
 	require.NoError(t, err)
 
 	err = lbTest.WaitForHTTPAvailable(lbSvc.Status.LoadBalancer.Ingress[0].IP, false)

--- a/tests/e2e/robot_test.go
+++ b/tests/e2e/robot_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -87,7 +88,7 @@ func TestServiceLoadBalancersRobot(t *testing.T) {
 		string(annotation.LBNodeSelector): "instance.hetzner.cloud/is-root-server=true",
 	})
 
-	lbSvc, err = lbTest.CreateService(lbSvc)
+	lbSvc, err = lbTest.CreateService(lbSvc, 8*time.Minute)
 	require.NoError(t, err)
 
 	err = lbTest.WaitForHTTPAvailable(lbSvc.Status.LoadBalancer.Ingress[0].IP, false)


### PR DESCRIPTION
- Increase Load Balancer creation timeout to prevent early test abort (previously decreased: https://github.com/hetznercloud/hcloud-cloud-controller-manager/commit/bccaddb74750e7273414fbf2ea54ae76f3ee97fe#diff-8d48bac6a439e62ea3b0740b26d2d6b9c93e1aeebc67aa9cc562abac695b13d5L291)
- If we can't cleanly destroy the namespace after three minutes we can info log the error and rely on the Servers being destroyed
- Cleanup all remaining Load Balancers when stopping the cluster