### PR TITLE
docs: remove duplicate changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,20 +14,6 @@
 - **helm**: remove permissions for persistentvolumes (#1203)
 - **route**: error handling on locked networks (#1215)
 
-## [v1.31.0](https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/tag/v1.31.0)
-
-### Features
-
-- **robot**: allow Robot support without API credentials for IP-based LB targets (#1163)
-- **helm**: allow customizing chart deployment strategy (#1190)
-- support Kubernetes v1.36
-- drop support for Kubernetes v1.32
-
-### Bug Fixes
-
-- **helm**: remove permissions for persistentvolumes (#1203)
-- **route**: error handling on locked networks (#1215)
-
 ## [v1.30.1](https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/tag/v1.30.1)
 
 ### Datacenter Deprecation


### PR DESCRIPTION
Due to an issue with release tooling, the changelog entry got duplicated.