### PR TITLE
test: run e2e tests against older k8s versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,16 @@ jobs:
       fail-fast: false # Continue tests matrix if a flaky run occurs.
       matrix:
         k3s:
+          - v1.23
+          - v1.24
+          - v1.25
+          - v1.26
+          - v1.27
+          - v1.28
+          - v1.29
+          - v1.30
+          - v1.31
+          - v1.32
           - v1.33
           - v1.34
           - v1.35


### PR DESCRIPTION
**Do not merge!**

Test against older versions of k8s to have an idea if we are still compatible with them.

