### PR TITLE
test(cache): merge cache tests by mode

### DIFF
--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -17,7 +17,7 @@ func assertServer1(t *testing.T, server *hcloud.Server) {
 	t.Helper()
 	require.NotNil(t, server)
 	assert.Equal(t, int64(1), server.ID)
-	assert.Equal(t, "test", server.Name)
+	assert.Equal(t, "test1", server.Name)
 }
 
 func assertServer2(t *testing.T, server *hcloud.Server) {
@@ -39,6 +39,19 @@ func newTestCache(mode Mode) *Cache[hcloud.Server] {
 	)
 }
 
+func assertCacheHasFreshServer(t *testing.T, cache *Cache[hcloud.Server], value *hcloud.Server) {
+	t.Helper()
+	assert.Equal(t, time.Now().Add(cache.defaultTTL), cache.byID[value.ID].expiresAt)
+	assert.Equal(t, value, cache.byID[value.ID].value)
+	assert.Equal(t, value, cache.byName[value.Name].value)
+}
+
+func assertCacheLen(t *testing.T, cache *Cache[hcloud.Server], length int) {
+	t.Helper()
+	assert.Len(t, cache.byID, length)
+	assert.Len(t, cache.byName, length)
+}
+
 type testClient struct {
 	t         *testing.T
 	callCount int
@@ -55,8 +68,12 @@ func (c *testClient) CallCount() int {
 func (c *testClient) FetchAllFunc(servers []*hcloud.Server, err error) func(context.Context) ([]*hcloud.Server, error) {
 	return func(context.Context) ([]*hcloud.Server, error) {
 		c.t.Helper()
-
 		c.callCount++
+
+		for i := range servers {
+			servers[i].Status = hcloud.ServerStatus(fmt.Sprintf("call=%d", c.callCount))
+		}
+
 		return servers, err
 	}
 }
@@ -64,12 +81,13 @@ func (c *testClient) FetchAllFunc(servers []*hcloud.Server, err error) func(cont
 func (c *testClient) FetchOneByIDFunc(server *hcloud.Server, err error) func(context.Context, int64) (*hcloud.Server, error) {
 	return func(_ context.Context, id int64) (*hcloud.Server, error) {
 		c.t.Helper()
+		c.callCount++
 
 		if server != nil {
 			require.Equal(c.t, server.ID, id, "fetch one by id expected id %d, got %d", server.ID, id)
+			server.Status = hcloud.ServerStatus(fmt.Sprintf("call=%d", c.callCount))
 		}
 
-		c.callCount++
 		return server, err
 	}
 }
@@ -77,279 +95,241 @@ func (c *testClient) FetchOneByIDFunc(server *hcloud.Server, err error) func(con
 func (c *testClient) FetchOneByNameFunc(server *hcloud.Server, err error) func(context.Context, string) (*hcloud.Server, error) {
 	return func(_ context.Context, name string) (*hcloud.Server, error) {
 		c.t.Helper()
+		c.callCount++
 
 		if server != nil {
 			require.Equal(c.t, server.Name, name, "fetch one by name expected name %s, got %s", server.Name, name)
+			server.Status = hcloud.ServerStatus(fmt.Sprintf("call=%d", c.callCount))
 		}
 
-		c.callCount++
 		return server, err
 	}
 }
 
 func TestCache_ModeAll(t *testing.T) {
-	sc := newTestCache(ModeAll)
-
-	ctx := t.Context()
-	client := newTestClient(t)
-
-	// Cache miss by ID 1, fetch from API
-	sc.fetchAll = client.FetchAllFunc([]*hcloud.Server{{ID: 1, Name: "test"}, {ID: 2, Name: "test2"}}, nil)
-
-	srv, err := sc.ByID(ctx, 1)
-	require.NoError(t, err)
-	assertServer1(t, srv)
-
-	// Fetch all returns 2 servers
-	assert.Equal(t, 1, client.CallCount())
-	assert.Len(t, sc.byID, 2)
-	assert.Len(t, sc.byName, 2)
-
-	assert.True(t, sc.byID[srv.ID].expiresAt.After(time.Now()))
-	assert.Equal(t, srv, sc.byID[srv.ID].value)
-	assert.Equal(t, srv, sc.byName[srv.Name].value)
-
-	// Cache hit by ID 1
-	srv, err = sc.ByID(ctx, 1)
-	require.NoError(t, err)
-	assertServer1(t, srv)
-
-	// Cache hit by ID 2
-	srv, err = sc.ByID(ctx, 2)
-	require.NoError(t, err)
-	assertServer2(t, srv)
-
-	// Cache hit by Name 1
-	srv, err = sc.ByName(ctx, "test")
-	require.NoError(t, err)
-	assertServer1(t, srv)
-
-	// Cache hit by Name 2
-	srv, err = sc.ByName(ctx, "test2")
-	require.NoError(t, err)
-	assertServer2(t, srv)
-
-	// Fetched two Servers with one API call
-	assert.Equal(t, 1, client.CallCount())
-}
-
-func TestCache_ModeAll_NotFound(t *testing.T) {
-	sc := newTestCache(ModeAll)
-
-	ctx := t.Context()
-	client := newTestClient(t)
-
-	// Cache miss by ID 1, fetch from API, not found
-	sc.fetchAll = client.FetchAllFunc([]*hcloud.Server{{ID: 2, Name: "test2"}, {ID: 3, Name: "test3"}}, nil)
-
-	srv, err := sc.ByID(ctx, 1)
-	require.NoError(t, err)
-	assert.Nil(t, srv)
-
-	// Fetch all returns 2 servers
-	assert.Equal(t, 1, client.CallCount())
-	assert.Len(t, sc.byID, 2)
-	assert.Len(t, sc.byName, 2)
-
-	// Cache hit by ID 2
-	srv, err = sc.ByID(ctx, 2)
-	require.NoError(t, err)
-	assertServer2(t, srv)
-
-	// Cache hit by Name "test2"
-	srv, err = sc.ByName(ctx, "test2")
-	require.NoError(t, err)
-	assertServer2(t, srv)
-
-	// Cache miss by name "test", fetch from API, not found
-	srv, err = sc.ByName(ctx, "test")
-	require.NoError(t, err)
-	assert.Nil(t, srv)
-
-	// Fetched two Servers with one API call
-	assert.Equal(t, 2, client.CallCount())
-}
-
-func TestCache_ModeOne(t *testing.T) {
-	sc := newTestCache(ModeOne)
-
-	ctx := t.Context()
-	client := newTestClient(t)
-
-	// Cache miss by ID 1, fetch from API
-	sc.fetchOneByID = client.FetchOneByIDFunc(&hcloud.Server{ID: 1, Name: "test"}, nil)
-
-	srv, err := sc.ByID(ctx, 1)
-	require.NoError(t, err)
-	assertServer1(t, srv)
-
-	// Fetched one server
-	assert.Equal(t, 1, client.CallCount())
-	assert.Len(t, sc.byID, 1)
-	assert.Len(t, sc.byName, 1)
-
-	assert.True(t, sc.byID[srv.ID].expiresAt.After(time.Now()))
-	assert.Equal(t, srv, sc.byID[srv.ID].value)
-	assert.Equal(t, srv, sc.byName[srv.Name].value)
-
-	// Cache hit by ID 1
-	srv, err = sc.ByID(ctx, 1)
-	require.NoError(t, err)
-	assertServer1(t, srv)
-
-	// Cache miss by ID 2, fetch from API
-	sc.fetchOneByID = client.FetchOneByIDFunc(&hcloud.Server{ID: 2, Name: "test2"}, nil)
-
-	srv, err = sc.ByID(ctx, 2)
-	require.NoError(t, err)
-	assertServer2(t, srv)
-
-	// Cache hit by Name 1
-	srv, err = sc.ByName(ctx, "test")
-	require.NoError(t, err)
-	assertServer1(t, srv)
-
-	// Cache hit by Name 2
-	srv, err = sc.ByName(ctx, "test2")
-	require.NoError(t, err)
-	assertServer2(t, srv)
-
-	// Fetched two servers individually
-	assert.Equal(t, 2, client.CallCount())
-}
-
-func TestCache_ModeOne_NotFound(t *testing.T) {
-	sc := newTestCache(ModeOne)
-
-	ctx := t.Context()
-	client := newTestClient(t)
-
-	// Cache miss by ID 1, fetch from API, not found
-	sc.fetchOneByID = client.FetchOneByIDFunc(nil, nil)
-
-	srv, err := sc.ByID(ctx, 1)
-	require.NoError(t, err)
-	assert.Nil(t, srv)
-
-	// Cached zero server
-	assert.Equal(t, 1, client.CallCount())
-	assert.Empty(t, sc.byID)
-	assert.Empty(t, sc.byName)
-
-	// Cache miss by ID 2, fetch from API
-	sc.fetchOneByID = client.FetchOneByIDFunc(&hcloud.Server{ID: 2, Name: "test2"}, nil)
-
-	srv, err = sc.ByID(ctx, 2)
-	require.NoError(t, err)
-	assertServer2(t, srv)
-
-	// Cached one server
-	assert.Equal(t, 2, client.CallCount())
-	assert.Len(t, sc.byID, 1)
-	assert.Len(t, sc.byName, 1)
-
-	// Cache miss by ID 1, fetch from API, not found
-	sc.fetchOneByID = client.FetchOneByIDFunc(nil, nil)
-
-	srv, err = sc.ByID(ctx, 1)
-	require.NoError(t, err)
-	assert.Nil(t, srv)
-
-	// Fetched zero server
-	assert.Equal(t, 3, client.CallCount())
-	assert.Len(t, sc.byID, 1)
-	assert.Len(t, sc.byName, 1)
-}
-
-func TestCache_ModeOff(t *testing.T) {
-	sc := newTestCache(ModeOff)
-
-	ctx := t.Context()
-	client := newTestClient(t)
-
-	// Cache miss by ID 1, fetch from API
-	sc.fetchOneByID = client.FetchOneByIDFunc(&hcloud.Server{ID: 1, Name: "test"}, nil)
-
-	srv, err := sc.ByID(ctx, 1)
-	require.NoError(t, err)
-	assertServer1(t, srv)
-
-	// Fetched one server
-	assert.Equal(t, 1, client.CallCount())
-	assert.Empty(t, sc.byID)
-	assert.Empty(t, sc.byName)
-
-	// Cache miss by ID 1, fetch from API
-	srv, err = sc.ByID(ctx, 1)
-	require.NoError(t, err)
-	assertServer1(t, srv)
-
-	assert.Equal(t, 2, client.CallCount())
-	// Entries are not cached
-	assert.Empty(t, sc.byID)
-	assert.Empty(t, sc.byName)
-
-	// Reset
-	sc.fetchOneByID = nil
-	client = newTestClient(t)
-
-	// Cache miss by Name "test", fetch from API
-	sc.fetchOneByName = client.FetchOneByNameFunc(&hcloud.Server{ID: 1, Name: "test"}, nil)
-
-	srv, err = sc.ByName(ctx, "test")
-	require.NoError(t, err)
-	assertServer1(t, srv)
-
-	// Fetched one server
-	assert.Equal(t, 1, client.CallCount())
-	assert.Empty(t, sc.byID)
-	assert.Empty(t, sc.byName)
-
-	// Cache miss by Name "test", fetch from API
-	srv, err = sc.ByName(ctx, "test")
-	require.NoError(t, err)
-	assertServer1(t, srv)
-
-	assert.Equal(t, 2, client.CallCount())
-	// Entries are not cached
-	assert.Empty(t, sc.byID)
-	assert.Empty(t, sc.byName)
-}
-
-func TestCache_ModeOne_EvictExpiredEntries(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		sc := newTestCache(ModeOne)
-
+		sc := newTestCache(ModeAll)
 		ctx := t.Context()
 		client := newTestClient(t)
 
-		// Populate cache
-		sc.fetchOneByID = client.FetchOneByIDFunc(&hcloud.Server{ID: 1, Name: "test"}, nil)
+		{
+			// cache miss (by id), fetch all
+			sc.fetchAll = client.FetchAllFunc([]*hcloud.Server{{ID: 1, Name: "test1"}, {ID: 2, Name: "test2"}}, nil)
 
-		srv, err := sc.ByID(ctx, 1)
-		require.NoError(t, err)
+			srv, err := sc.ByID(ctx, 1)
+			require.NoError(t, err)
+			assertServer1(t, srv)
+			assert.Equal(t, 1, client.CallCount())
 
-		assert.Equal(t, time.Now().Add(sc.defaultTTL), sc.byID[srv.ID].expiresAt)
+			assertCacheLen(t, sc, 2)
+			assertCacheHasFreshServer(t, sc, srv)
+		}
+		{
+			// cache hit (by id)
+			srv, err := sc.ByID(ctx, 1)
+			require.NoError(t, err)
+			assertServer1(t, srv)
+			assert.Equal(t, 1, client.CallCount())
+		}
+		{
+			// cache hit (by name)
+			srv, err := sc.ByName(ctx, "test1")
+			require.NoError(t, err)
+			assertServer1(t, srv)
+			assert.Equal(t, 1, client.CallCount())
+		}
+		time.Sleep(sc.defaultTTL - time.Second)
+		{
+			// cache hit (by id)
+			srv, err := sc.ByID(ctx, 2)
+			require.NoError(t, err)
+			assertServer2(t, srv)
+			assert.Equal(t, 1, client.CallCount())
+		}
+		{
+			// cache hit (by name)
+			srv, err := sc.ByName(ctx, "test2")
+			require.NoError(t, err)
+			assertServer2(t, srv)
+			assert.Equal(t, 1, client.CallCount())
+		}
+		time.Sleep(time.Second)
+		{
+			// cache expired (by id), fetch all
+			sc.fetchAll = client.FetchAllFunc([]*hcloud.Server{{ID: 1, Name: "test1"}}, nil)
 
-		// Wait for expiration plus the eviction grace period (entries are only
-		// evicted once they have been expired for at least an hour).
-		time.Sleep(sc.defaultTTL + time.Hour + 1)
+			srv, err := sc.ByID(ctx, 1)
+			require.NoError(t, err)
+			assertServer1(t, srv)
+			assert.Equal(t, 2, client.CallCount())
 
-		// Cache miss by ID 2, fetch from API
-		sc.fetchOneByID = client.FetchOneByIDFunc(&hcloud.Server{ID: 2, Name: "test2"}, nil)
+			assertCacheLen(t, sc, 1)
+			assertCacheHasFreshServer(t, sc, srv)
+		}
+		{
+			// cache miss (by id), fetch all, not found
+			srv, err := sc.ByID(ctx, 2)
+			require.NoError(t, err)
+			assert.Nil(t, srv)
+			assert.Equal(t, 3, client.CallCount())
 
-		srv, err = sc.ByID(ctx, 2)
-		require.NoError(t, err)
-		assertServer2(t, srv)
+			assertCacheLen(t, sc, 1)
+		}
+		{
+			// cache hit (by id)
+			srv, err := sc.ByID(ctx, 1)
+			require.NoError(t, err)
+			assertServer1(t, srv)
+			assert.Equal(t, 3, client.CallCount())
+		}
+		{
+			// cache miss (by id), fetch all, not found
+			srv, err := sc.ByID(ctx, 2)
+			require.NoError(t, err)
+			assert.Nil(t, srv)
+			assert.Equal(t, 4, client.CallCount())
 
-		// Fetched two servers individually
-		assert.Equal(t, 2, client.CallCount())
+			assertCacheLen(t, sc, 1)
+		}
+	})
+}
 
-		// Server ID 1 has been evicted
-		assert.Len(t, sc.byID, 1)
-		assert.Len(t, sc.byName, 1)
-		assert.Nil(t, sc.byID[1])
-		assert.Nil(t, sc.byName["test"])
+func TestCache_ModeOne(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		sc := newTestCache(ModeOne)
+		ctx := t.Context()
+		client := newTestClient(t)
+
+		{
+			// cache miss (by id), fetch one
+			sc.fetchOneByID = client.FetchOneByIDFunc(&hcloud.Server{ID: 1, Name: "test1"}, nil)
+
+			srv, err := sc.ByID(ctx, 1)
+			require.NoError(t, err)
+			assertServer1(t, srv)
+			assert.Equal(t, 1, client.CallCount())
+
+			// - test1 is fresh
+			assertCacheLen(t, sc, 1)
+			assertCacheHasFreshServer(t, sc, srv)
+		}
+		time.Sleep(sc.defaultTTL - time.Second)
+		{
+			// cache hit (by id)
+			srv, err := sc.ByID(ctx, 1)
+			require.NoError(t, err)
+			assertServer1(t, srv)
+			assert.Equal(t, 1, client.CallCount())
+		}
+		{
+			// cache hit (by name)
+			srv, err := sc.ByName(ctx, "test1")
+			require.NoError(t, err)
+			assertServer1(t, srv)
+			assert.Equal(t, 1, client.CallCount())
+		}
+		{
+			// cache miss (by id), fetch one
+			sc.fetchOneByID = client.FetchOneByIDFunc(&hcloud.Server{ID: 2, Name: "test2"}, nil)
+
+			srv, err := sc.ByID(ctx, 2)
+			require.NoError(t, err)
+			assertServer2(t, srv)
+			assert.Equal(t, 2, client.CallCount())
+
+			// - test1 is soon expired
+			// - test2 is fresh
+			assertCacheLen(t, sc, 2)
+			assertCacheHasFreshServer(t, sc, srv)
+		}
+		time.Sleep(time.Second)
+		{
+			// cache hit (by id)
+			srv, err := sc.ByID(ctx, 2)
+			require.NoError(t, err)
+			assertServer2(t, srv)
+			assert.Equal(t, 2, client.CallCount())
+		}
+		{
+			// cache hit (by name)
+			srv, err := sc.ByName(ctx, "test2")
+			require.NoError(t, err)
+			assertServer2(t, srv)
+			assert.Equal(t, 2, client.CallCount())
+		}
+		{
+			// cache expired (by id), fetch one
+			sc.fetchOneByID = client.FetchOneByIDFunc(&hcloud.Server{ID: 1, Name: "test1"}, nil)
+
+			srv, err := sc.ByID(ctx, 1)
+			require.NoError(t, err)
+			assertServer1(t, srv)
+			assert.Equal(t, 3, client.CallCount())
+
+			// - test1 is fresh
+			// - test2 is fresh
+			assertCacheLen(t, sc, 2)
+			assertCacheHasFreshServer(t, sc, srv)
+		}
+		time.Sleep(sc.defaultTTL)
+		{
+			// cache expired (by id), fetch one, not found
+			sc.fetchOneByID = client.FetchOneByIDFunc(nil, nil)
+
+			srv, err := sc.ByID(ctx, 1)
+			require.NoError(t, err)
+			assert.Nil(t, srv)
+			assert.Equal(t, 4, client.CallCount())
+
+			// - test1 is expired
+			// - test2 is expired
+			assertCacheLen(t, sc, 2)
+		}
+		time.Sleep(time.Hour + time.Second)
+		{
+			// cache expired (by id), fetch one
+			sc.fetchOneByID = client.FetchOneByIDFunc(&hcloud.Server{ID: 2, Name: "test2"}, nil)
+
+			srv, err := sc.ByID(ctx, 2)
+			require.NoError(t, err)
+			assertServer2(t, srv)
+			assert.Equal(t, 5, client.CallCount())
+
+			// - test1 was evicted
+			// - test2 is fresh
+			assertCacheLen(t, sc, 1)
+			assertCacheHasFreshServer(t, sc, srv)
+		}
+		// We evict only after ttl+hour, not after hour.
+		time.Sleep(sc.defaultTTL)
+		time.Sleep(time.Hour + time.Second)
+		{
+			// cache miss (by id), fetch one, not found
+			sc.fetchOneByID = client.FetchOneByIDFunc(nil, nil)
+
+			srv, err := sc.ByID(ctx, 1)
+			require.NoError(t, err)
+			assert.Nil(t, srv)
+			assert.Equal(t, 6, client.CallCount())
+
+			// - test1 was not found and the cache untouched
+			// - test2 was not evicted because test1 was not found
+			assertCacheLen(t, sc, 1)
+		}
+		{
+			// cache miss (by id), fetch one
+			sc.fetchOneByID = client.FetchOneByIDFunc(&hcloud.Server{ID: 1, Name: "test1"}, nil)
+
+			srv, err := sc.ByID(ctx, 1)
+			require.NoError(t, err)
+			assertServer1(t, srv)
+			assert.Equal(t, 7, client.CallCount())
+
+			// - test1 is fresh
+			// - test2 was evicted
+			assertCacheLen(t, sc, 1)
+			assertCacheHasFreshServer(t, sc, srv)
+		}
 	})
 }
 
@@ -361,7 +341,7 @@ func TestCache_ModeOne_WithTTLRefreshOpts(t *testing.T) {
 		client := newTestClient(t)
 
 		// Populate cache with default TTL
-		sc.fetchOneByID = client.FetchOneByIDFunc(&hcloud.Server{ID: 1, Name: "test"}, nil)
+		sc.fetchOneByID = client.FetchOneByIDFunc(&hcloud.Server{ID: 1, Name: "test1"}, nil)
 
 		srv, err := sc.ByID(ctx, 1)
 		require.NoError(t, err)
@@ -410,7 +390,7 @@ func TestCache_ModeOne_WithModeRefreshOpts(t *testing.T) {
 		client := newTestClient(t)
 
 		// Populate cache with default TTL
-		sc.fetchOneByID = client.FetchOneByIDFunc(&hcloud.Server{ID: 1, Name: "test", Status: hcloud.ServerStatusRunning}, nil)
+		sc.fetchOneByID = client.FetchOneByIDFunc(&hcloud.Server{ID: 1, Name: "test1"}, nil)
 
 		srv, err := sc.ByID(ctx, 1)
 		require.NoError(t, err)
@@ -418,13 +398,13 @@ func TestCache_ModeOne_WithModeRefreshOpts(t *testing.T) {
 		assert.Equal(t, time.Now().Add(sc.defaultTTL), sc.byID[srv.ID].expiresAt)
 
 		// Cache miss by ID 2, fetch from API with different TTL
-		sc.fetchOneByID = client.FetchOneByIDFunc(&hcloud.Server{ID: 2, Name: "test2", Status: hcloud.ServerStatusOff}, nil)
+		sc.fetchOneByID = client.FetchOneByIDFunc(&hcloud.Server{ID: 2, Name: "test2"}, nil)
 
 		// Fetch Server ID 2, use larger TTL
 		srv, err = sc.ByID(ctx, 2)
 		require.NoError(t, err)
 		assertServer2(t, srv)
-		assert.Equal(t, hcloud.ServerStatusOff, srv.Status)
+		assert.Equal(t, "call=2", string(srv.Status))
 		assert.Equal(t, time.Now().Add(sc.defaultTTL), sc.byID[srv.ID].expiresAt)
 
 		// Wait for expiration of Server ID 1 and 2
@@ -433,8 +413,8 @@ func TestCache_ModeOne_WithModeRefreshOpts(t *testing.T) {
 		// Ensure we only call fetchAll
 		sc.fetchOneByID = nil
 		sc.fetchAll = client.FetchAllFunc([]*hcloud.Server{
-			{ID: 1, Name: "test", Status: hcloud.ServerStatusRunning},
-			{ID: 2, Name: "test2", Status: hcloud.ServerStatusRunning},
+			{ID: 1, Name: "test1"},
+			{ID: 2, Name: "test2"},
 		}, nil)
 
 		srv, err = sc.ByID(ctx, 1, WithMode(ModeAll))
@@ -445,7 +425,7 @@ func TestCache_ModeOne_WithModeRefreshOpts(t *testing.T) {
 		srv, err = sc.ByID(ctx, 2)
 		require.NoError(t, err)
 		assertServer2(t, srv)
-		assert.Equal(t, hcloud.ServerStatusRunning, srv.Status)
+		assert.Equal(t, "call=3", string(srv.Status))
 
 		// Expect two API calls
 		assert.Equal(t, 3, client.CallCount())
@@ -461,6 +441,54 @@ func TestCache_ModeOne_WithModeRefreshOpts(t *testing.T) {
 		// Server ID 2 is still fresh -> higher TTL with `WithTTL` option
 		assert.True(t, time.Now().Before(sc.byID[2].expiresAt))
 	})
+}
+
+func TestCache_ModeOff(t *testing.T) {
+	sc := newTestCache(ModeOff)
+
+	ctx := t.Context()
+	client := newTestClient(t)
+
+	// Cache miss by ID 1, fetch from API
+	sc.fetchOneByID = client.FetchOneByIDFunc(&hcloud.Server{ID: 1, Name: "test1"}, nil)
+
+	srv, err := sc.ByID(ctx, 1)
+	require.NoError(t, err)
+	assertServer1(t, srv)
+
+	assert.Equal(t, 1, client.CallCount())
+	assert.Empty(t, sc.byID)
+	assert.Empty(t, sc.byName)
+
+	// Cache miss by ID 1, fetch from API
+	srv, err = sc.ByID(ctx, 1)
+	require.NoError(t, err)
+	assertServer1(t, srv)
+
+	assert.Equal(t, 2, client.CallCount())
+	assert.Empty(t, sc.byID)
+	assert.Empty(t, sc.byName)
+
+	// Cache miss by Name "test1", fetch from API
+	sc.fetchOneByID = nil
+	sc.fetchOneByName = client.FetchOneByNameFunc(&hcloud.Server{ID: 1, Name: "test1"}, nil)
+
+	srv, err = sc.ByName(ctx, "test1")
+	require.NoError(t, err)
+	assertServer1(t, srv)
+
+	assert.Equal(t, 3, client.CallCount())
+	assert.Empty(t, sc.byID)
+	assert.Empty(t, sc.byName)
+
+	// Cache miss by Name "test1", fetch from API
+	srv, err = sc.ByName(ctx, "test1")
+	require.NoError(t, err)
+	assertServer1(t, srv)
+
+	assert.Equal(t, 4, client.CallCount())
+	assert.Empty(t, sc.byID)
+	assert.Empty(t, sc.byName)
 }
 
 func TestCache_Error(t *testing.T) {
@@ -495,8 +523,8 @@ func TestCache_Error(t *testing.T) {
 		sc.fetchOneByName = client.FetchOneByNameFunc(nil, fmt.Errorf("test error"))
 		sc.fetchAll = client.FetchAllFunc(nil, fmt.Errorf("test error"))
 
-		// Cache miss by name "test", fetch from API
-		srv, err = sc.ByName(ctx, "test")
+		// Cache miss by name "test1", fetch from API
+		srv, err = sc.ByName(ctx, "test1")
 		require.ErrorContains(t, err, "test error")
 		assert.Nil(t, srv)
 
@@ -505,7 +533,7 @@ func TestCache_Error(t *testing.T) {
 		assert.Empty(t, sc.byName)
 
 		// Second time still errors - two API calls
-		srv, err = sc.ByName(ctx, "test")
+		srv, err = sc.ByName(ctx, "test1")
 		require.ErrorContains(t, err, "test error")
 		assert.Nil(t, srv)
 		assert.Equal(t, 2, client.CallCount())

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -87,7 +87,7 @@ func (c *testClient) FetchOneByNameFunc(server *hcloud.Server, err error) func(c
 	}
 }
 
-func TestServerCacheModeAllServers(t *testing.T) {
+func TestCache_ModeAll(t *testing.T) {
 	sc := newTestCache(ModeAll)
 
 	ctx := t.Context()
@@ -133,7 +133,7 @@ func TestServerCacheModeAllServers(t *testing.T) {
 	assert.Equal(t, 1, client.CallCount())
 }
 
-func TestServerCacheModeAllServersNotFound(t *testing.T) {
+func TestCache_ModeAll_NotFound(t *testing.T) {
 	sc := newTestCache(ModeAll)
 
 	ctx := t.Context()
@@ -170,7 +170,7 @@ func TestServerCacheModeAllServersNotFound(t *testing.T) {
 	assert.Equal(t, 2, client.CallCount())
 }
 
-func TestServerCacheModePerServer(t *testing.T) {
+func TestCache_ModeOne(t *testing.T) {
 	sc := newTestCache(ModeOne)
 
 	ctx := t.Context()
@@ -218,7 +218,7 @@ func TestServerCacheModePerServer(t *testing.T) {
 	assert.Equal(t, 2, client.CallCount())
 }
 
-func TestServerCacheModeOneNotFound(t *testing.T) {
+func TestCache_ModeOne_NotFound(t *testing.T) {
 	sc := newTestCache(ModeOne)
 
 	ctx := t.Context()
@@ -261,7 +261,7 @@ func TestServerCacheModeOneNotFound(t *testing.T) {
 	assert.Len(t, sc.byName, 1)
 }
 
-func TestServerCacheModeOff(t *testing.T) {
+func TestCache_ModeOff(t *testing.T) {
 	sc := newTestCache(ModeOff)
 
 	ctx := t.Context()
@@ -316,7 +316,7 @@ func TestServerCacheModeOff(t *testing.T) {
 	assert.Empty(t, sc.byName)
 }
 
-func TestServerCacheModePerServer_EvictExpiredEntries(t *testing.T) {
+func TestCache_ModeOne_EvictExpiredEntries(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		sc := newTestCache(ModeOne)
 
@@ -353,7 +353,7 @@ func TestServerCacheModePerServer_EvictExpiredEntries(t *testing.T) {
 	})
 }
 
-func TestServerCacheModePerServer_WithTTLRefreshOpts(t *testing.T) {
+func TestCache_ModeOne_WithTTLRefreshOpts(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		sc := newTestCache(ModeOne)
 
@@ -402,7 +402,7 @@ func TestServerCacheModePerServer_WithTTLRefreshOpts(t *testing.T) {
 	})
 }
 
-func TestServerCacheModePerServer_WithModeRefreshOpts(t *testing.T) {
+func TestCache_ModeOne_WithModeRefreshOpts(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		sc := newTestCache(ModeOne)
 
@@ -463,7 +463,7 @@ func TestServerCacheModePerServer_WithModeRefreshOpts(t *testing.T) {
 	})
 }
 
-func TestServerCacheAllModesError(t *testing.T) {
+func TestCache_Error(t *testing.T) {
 	testCase := func(t *testing.T, mode Mode) {
 		sc := newTestCache(mode)
 


### PR DESCRIPTION
- Merge existing cache tests by mode
- Use synctest in each cache mode tests (allows to mix "normal", "api not found", and "entries eviction" cases)
- Add few testing/debugging helpers