### PR TITLE
docs: fix duration type documentation

### DIFF
--- a/docs/reference/load_balancer_envs.md
+++ b/docs/reference/load_balancer_envs.md
@@ -4,7 +4,8 @@ This page contains all environment variables, which can be specified to configur
 
 Some environment variables define global defaults. These defaults can be overridden by setting the corresponding annotation. If you remove such an annotation while a global default is configured, the global default will be applied again.
 
-Enums are depicted in the `Type` column and possible options are separated via the pipe symbol `|`.
+- Enums are depicted in the `Type` column and possible options are separated via the pipe symbol `|`.
+- The `duration` type is a Go duration string, i.e. a sequence of decimal numbers each with a unit suffix such as `300ms`, `30s`, `5m` or `1h` (see [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration)).
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -16,9 +17,9 @@ Enums are depicted in the `Type` column and possible options are separated via t
 | `HCLOUD_LOAD_BALANCERS_DISABLE_IPV6` | `bool` | `false` | Disables the use of IPv6 for the Load Balancer by default. |
 | `HCLOUD_LOAD_BALANCERS_ALGORITHM_TYPE` | `round_robin \| least_connections` | `round_robin` | Configures the default Load Balancer algorithm. |
 | `HCLOUD_LOAD_BALANCERS_DISABLE_PUBLIC_NETWORK` | `bool` | `false` | Disables the public interface of the Load Balancer by default. |
-| `HCLOUD_LOAD_BALANCERS_HEALTH_CHECK_INTERVAL` | `int` | `10` | Configures the default time interval in seconds in which health checks are performed. |
+| `HCLOUD_LOAD_BALANCERS_HEALTH_CHECK_INTERVAL` | `duration` | `10s` | Configures the default time interval in which health checks are performed. |
 | `HCLOUD_LOAD_BALANCERS_HEALTH_CHECK_RETRIES` | `int` | `3` | Configures the default amount of unsuccessful retries needed until a target is considered unhealthy. |
-| `HCLOUD_LOAD_BALANCERS_HEALTH_CHECK_TIMEOUT` | `int` | `15` | Configures the default time in seconds after an attempt is considered a timeout. |
+| `HCLOUD_LOAD_BALANCERS_HEALTH_CHECK_TIMEOUT` | `duration` | `15s` | Configures the default time after an attempt is considered a timeout. |
 | `HCLOUD_LOAD_BALANCERS_PRIVATE_SUBNET_IP_RANGE` | `string` | `-` | Configures the default IP range in CIDR block notation of the subnet to attach to. |
 | `HCLOUD_LOAD_BALANCERS_TYPE` | `string` | `lb11` | Configures the default Load Balancer type this Load Balancer should be created with. |
 | `HCLOUD_LOAD_BALANCERS_USES_PROXYPROTOCOL` | `bool` | `false` | Enables the proxyprotocol for a Load Balancer service by default. |

--- a/internal/config/load_balancer_envs.go
+++ b/internal/config/load_balancer_envs.go
@@ -54,11 +54,11 @@ const (
 	// Default: false
 	hcloudLoadBalancersDisablePublicNetwork = "HCLOUD_LOAD_BALANCERS_DISABLE_PUBLIC_NETWORK"
 
-	// hcloudLoadBalancersHealthCheckInterval configures the default time interval in seconds
+	// hcloudLoadBalancersHealthCheckInterval configures the default time interval
 	// in which health checks are performed.
 	//
-	// Type: int
-	// Default: 10
+	// Type: duration
+	// Default: 10s
 	hcloudLoadBalancersHealthCheckInterval = "HCLOUD_LOAD_BALANCERS_HEALTH_CHECK_INTERVAL"
 
 	// hcloudLoadBalancersHealthCheckRetries configures the default amount of unsuccessful retries
@@ -68,11 +68,11 @@ const (
 	// Default: 3
 	hcloudLoadBalancersHealthCheckRetries = "HCLOUD_LOAD_BALANCERS_HEALTH_CHECK_RETRIES"
 
-	// hcloudLoadBalancersHealthCheckTimeout configures the default time in seconds after an attempt is
+	// hcloudLoadBalancersHealthCheckTimeout configures the default time after an attempt is
 	// considered a timeout.
 	//
-	// Type: int
-	// Default: 15
+	// Type: duration
+	// Default: 15s
 	hcloudLoadBalancersHealthCheckTimeout = "HCLOUD_LOAD_BALANCERS_HEALTH_CHECK_TIMEOUT"
 
 	// hcloudLoadBalancersPrivateSubnetIPRange configures the default IP range in CIDR block notation of

--- a/tools/load_balancer_envs.md.tmpl
+++ b/tools/load_balancer_envs.md.tmpl
@@ -4,6 +4,7 @@ This page contains all environment variables, which can be specified to configur
 
 Some environment variables define global defaults. These defaults can be overridden by setting the corresponding annotation. If you remove such an annotation while a global default is configured, the global default will be applied again.
 
-Enums are depicted in the `Type` column and possible options are separated via the pipe symbol `|`.
+- Enums are depicted in the `Type` column and possible options are separated via the pipe symbol `|`.
+- The `duration` type is a Go duration string, i.e. a sequence of decimal numbers each with a unit suffix such as `300ms`, `30s`, `5m` or `1h` (see [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration)).
 
 {{.ConstTable}}


### PR DESCRIPTION
The value was always parsed via the Go type and not as int.
The documentation was wrong.
