### PR TITLE
refactor: use plain strings for service annotation fixtures

### DIFF
--- a/hcloud/load_balancers_test.go
+++ b/hcloud/load_balancers_test.go
@@ -29,8 +29,8 @@ func TestLoadBalancers_GetLoadBalancer(t *testing.T) {
 		{
 			Name:       "get load balancer without host name IPv6 disabled",
 			ServiceUID: "1",
-			ServiceAnnotations: map[annotation.Name]string{
-				annotation.LBIPv6Disabled: "true",
+			ServiceAnnotations: map[string]string{
+				string(annotation.LBIPv6Disabled): "true",
 			},
 			LB: &hcloud.LoadBalancer{
 				ID:   1,
@@ -94,8 +94,8 @@ func TestLoadBalancers_GetLoadBalancer(t *testing.T) {
 					On("GetByK8SServiceUID", tt.Ctx, tt.Service).
 					Return(tt.LB, nil)
 			},
-			ServiceAnnotations: map[annotation.Name]string{
-				annotation.LBHostname: "hostname",
+			ServiceAnnotations: map[string]string{
+				string(annotation.LBHostname): "hostname",
 			},
 			Perform: func(t *testing.T, tt *LoadBalancerTestCase) {
 				status, exists, err := tt.LoadBalancers.GetLoadBalancer(tt.Ctx, tt.ClusterName, tt.Service)
@@ -264,9 +264,9 @@ func TestLoadBalancers_EnsureLoadBalancer_CreateLoadBalancer(t *testing.T) {
 		{
 			Name:       "public network only no ipv6",
 			ServiceUID: "2",
-			ServiceAnnotations: map[annotation.Name]string{
-				annotation.LBName:         "pub-net-only-no-ipv6",
-				annotation.LBIPv6Disabled: "true",
+			ServiceAnnotations: map[string]string{
+				string(annotation.LBName):         "pub-net-only-no-ipv6",
+				string(annotation.LBIPv6Disabled): "true",
 			},
 			LB: &hcloud.LoadBalancer{
 				ID:               1,
@@ -295,8 +295,8 @@ func TestLoadBalancers_EnsureLoadBalancer_CreateLoadBalancer(t *testing.T) {
 		{
 			Name:       "public network only",
 			ServiceUID: "2",
-			ServiceAnnotations: map[annotation.Name]string{
-				annotation.LBName: "pub-net-only",
+			ServiceAnnotations: map[string]string{
+				string(annotation.LBName): "pub-net-only",
 			},
 			LB: &hcloud.LoadBalancer{
 				ID:               1,
@@ -328,8 +328,8 @@ func TestLoadBalancers_EnsureLoadBalancer_CreateLoadBalancer(t *testing.T) {
 			Name:       "attach Load Balancer to public and private network",
 			NetworkID:  4711,
 			ServiceUID: "3",
-			ServiceAnnotations: map[annotation.Name]string{
-				annotation.LBName: "with-priv-net",
+			ServiceAnnotations: map[string]string{
+				string(annotation.LBName): "with-priv-net",
 			},
 			LB: &hcloud.LoadBalancer{
 				ID:               1,
@@ -371,8 +371,8 @@ func TestLoadBalancers_EnsureLoadBalancer_CreateLoadBalancer(t *testing.T) {
 			Name:       "disable private ingress via default",
 			NetworkID:  4711,
 			ServiceUID: "5",
-			ServiceAnnotations: map[annotation.Name]string{
-				annotation.LBName: "with-priv-net-no-priv-ingress",
+			ServiceAnnotations: map[string]string{
+				string(annotation.LBName): "with-priv-net-no-priv-ingress",
 			},
 			UsePrivateIngressDefault: new(false),
 			LB: &hcloud.LoadBalancer{
@@ -414,9 +414,9 @@ func TestLoadBalancers_EnsureLoadBalancer_CreateLoadBalancer(t *testing.T) {
 			Name:       "disable private ingress via annotation",
 			NetworkID:  4711,
 			ServiceUID: "5",
-			ServiceAnnotations: map[annotation.Name]string{
-				annotation.LBName:                  "with-priv-net-no-priv-ingress",
-				annotation.LBDisablePrivateIngress: "true",
+			ServiceAnnotations: map[string]string{
+				string(annotation.LBName):                  "with-priv-net-no-priv-ingress",
+				string(annotation.LBDisablePrivateIngress): "true",
 			},
 			LB: &hcloud.LoadBalancer{
 				ID:               1,
@@ -457,9 +457,9 @@ func TestLoadBalancers_EnsureLoadBalancer_CreateLoadBalancer(t *testing.T) {
 			Name:       "attach Load Balancer to private network only",
 			NetworkID:  4711,
 			ServiceUID: "6",
-			ServiceAnnotations: map[annotation.Name]string{
-				annotation.LBName:                 "priv-net-only",
-				annotation.LBDisablePublicNetwork: "true",
+			ServiceAnnotations: map[string]string{
+				string(annotation.LBName):                 "priv-net-only",
+				string(annotation.LBDisablePublicNetwork): "true",
 			},
 			LB: &hcloud.LoadBalancer{
 				ID:               1,
@@ -511,9 +511,9 @@ func TestLoadBalancers_EnsureLoadBalancer_CreateLoadBalancer(t *testing.T) {
 			Name:       "attach Load Balancer to public and private network (with proxy protocol)",
 			NetworkID:  4711,
 			ServiceUID: "3",
-			ServiceAnnotations: map[annotation.Name]string{
-				annotation.LBName:             "with-priv-net",
-				annotation.LBSvcProxyProtocol: "true",
+			ServiceAnnotations: map[string]string{
+				string(annotation.LBName):             "with-priv-net",
+				string(annotation.LBSvcProxyProtocol): "true",
 			},
 			LB: &hcloud.LoadBalancer{
 				ID:               1,
@@ -561,8 +561,8 @@ func TestLoadBalancer_EnsureLoadBalancer_UpdateLoadBalancer(t *testing.T) {
 		{
 			Name:       "Load balancer unchanged",
 			ServiceUID: "1",
-			ServiceAnnotations: map[annotation.Name]string{
-				annotation.LBName: "test-lb",
+			ServiceAnnotations: map[string]string{
+				string(annotation.LBName): "test-lb",
 			},
 			LB: &hcloud.LoadBalancer{
 				ID:               1,
@@ -583,8 +583,8 @@ func TestLoadBalancer_EnsureLoadBalancer_UpdateLoadBalancer(t *testing.T) {
 		{
 			Name:       "Load balancer changed",
 			ServiceUID: "2",
-			ServiceAnnotations: map[annotation.Name]string{
-				annotation.LBName: "test-lb",
+			ServiceAnnotations: map[string]string{
+				string(annotation.LBName): "test-lb",
 			},
 			LB: &hcloud.LoadBalancer{
 				ID:               2,
@@ -606,8 +606,8 @@ func TestLoadBalancer_EnsureLoadBalancer_UpdateLoadBalancer(t *testing.T) {
 		{
 			Name:       "Load balancer targets changed",
 			ServiceUID: "3",
-			ServiceAnnotations: map[annotation.Name]string{
-				annotation.LBName: "test-lb",
+			ServiceAnnotations: map[string]string{
+				string(annotation.LBName): "test-lb",
 			},
 			LB: &hcloud.LoadBalancer{
 				ID:               3,
@@ -629,8 +629,8 @@ func TestLoadBalancer_EnsureLoadBalancer_UpdateLoadBalancer(t *testing.T) {
 		{
 			Name:       "Load balancer services changed",
 			ServiceUID: "4",
-			ServiceAnnotations: map[annotation.Name]string{
-				annotation.LBName: "test-lb",
+			ServiceAnnotations: map[string]string{
+				string(annotation.LBName): "test-lb",
 			},
 			LB: &hcloud.LoadBalancer{
 				ID:               4,
@@ -652,8 +652,8 @@ func TestLoadBalancer_EnsureLoadBalancer_UpdateLoadBalancer(t *testing.T) {
 		{
 			Name:       "fall back to load balancer name",
 			ServiceUID: "5",
-			ServiceAnnotations: map[annotation.Name]string{
-				annotation.LBName: "pre-existing-lb",
+			ServiceAnnotations: map[string]string{
+				string(annotation.LBName): "pre-existing-lb",
 			},
 			LB: &hcloud.LoadBalancer{
 				ID:               5,
@@ -684,8 +684,8 @@ func TestLoadBalancer_UpdateLoadBalancer(t *testing.T) {
 		{
 			Name:       "Load Balancer not found",
 			ServiceUID: "1",
-			ServiceAnnotations: map[annotation.Name]string{
-				annotation.LBName: "test-lb",
+			ServiceAnnotations: map[string]string{
+				string(annotation.LBName): "test-lb",
 			},
 			Mock: func(_ *testing.T, tt *LoadBalancerTestCase) {
 				tt.LBOps.On("GetByK8SServiceUID", tt.Ctx, tt.Service).Return(nil, hcops.ErrNotFound)
@@ -699,8 +699,8 @@ func TestLoadBalancer_UpdateLoadBalancer(t *testing.T) {
 		{
 			Name:       "calls all reconcilement ops",
 			ServiceUID: "2",
-			ServiceAnnotations: map[annotation.Name]string{
-				annotation.LBName: "test-lb",
+			ServiceAnnotations: map[string]string{
+				string(annotation.LBName): "test-lb",
 			},
 			LB: &hcloud.LoadBalancer{
 				ID:               1,
@@ -721,8 +721,8 @@ func TestLoadBalancer_UpdateLoadBalancer(t *testing.T) {
 		{
 			Name:       "fall back to load balancer name",
 			ServiceUID: "3",
-			ServiceAnnotations: map[annotation.Name]string{
-				annotation.LBName: "previously-created-lb",
+			ServiceAnnotations: map[string]string{
+				string(annotation.LBName): "previously-created-lb",
 			},
 			LB: &hcloud.LoadBalancer{
 				ID:               3,

--- a/hcloud/testing.go
+++ b/hcloud/testing.go
@@ -2,13 +2,13 @@ package hcloud
 
 import (
 	"context"
+	"maps"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/annotation"
 	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/config"
 	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/hcops"
 	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/mocks"
@@ -22,7 +22,7 @@ type LoadBalancerTestCase struct {
 	ClusterName              string
 	NetworkID                int
 	ServiceUID               string
-	ServiceAnnotations       map[annotation.Name]string
+	ServiceAnnotations       map[string]string
 	UsePrivateIngressDefault *bool
 	UseIPv6Default           *bool
 	Nodes                    []*corev1.Node
@@ -68,9 +68,7 @@ func (tt *LoadBalancerTestCase) run(t *testing.T) {
 			Annotations: map[string]string{},
 		},
 	}
-	for k, v := range tt.ServiceAnnotations {
-		tt.Service.Annotations[string(k)] = v
-	}
+	maps.Copy(tt.Service.Annotations, tt.ServiceAnnotations)
 	if tt.Ctx == nil {
 		tt.Ctx = context.Background()
 	}

--- a/internal/hcops/load_balancer_internal_test.go
+++ b/internal/hcops/load_balancer_internal_test.go
@@ -2,6 +2,7 @@ package hcops
 
 import (
 	"fmt"
+	"maps"
 	"testing"
 	"time"
 
@@ -22,7 +23,7 @@ func TestHCLBServiceOptsBuilder(t *testing.T) {
 		name               string
 		servicePort        corev1.ServicePort
 		serviceUID         string
-		serviceAnnotations map[annotation.Name]string
+		serviceAnnotations map[string]string
 		cfg                config.LoadBalancerConfiguration
 		expectedAddOpts    hcloud.LoadBalancerAddServiceOpts
 		expectedUpdateOpts hcloud.LoadBalancerUpdateServiceOpts
@@ -58,8 +59,8 @@ func TestHCLBServiceOptsBuilder(t *testing.T) {
 		{
 			name:        "enable proxy protocol",
 			servicePort: corev1.ServicePort{Port: 81, NodePort: 8081},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBSvcProxyProtocol: "true",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBSvcProxyProtocol): "true",
 			},
 			expectedAddOpts: hcloud.LoadBalancerAddServiceOpts{
 				ListenPort:      new(81),
@@ -87,8 +88,8 @@ func TestHCLBServiceOptsBuilder(t *testing.T) {
 			cfg: config.LoadBalancerConfiguration{
 				ProxyProtocolEnabled: new(true),
 			},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBSvcProxyProtocol: "false",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBSvcProxyProtocol): "false",
 			},
 			expectedAddOpts: hcloud.LoadBalancerAddServiceOpts{
 				ListenPort:      new(86),
@@ -113,14 +114,14 @@ func TestHCLBServiceOptsBuilder(t *testing.T) {
 		{
 			name:        "select HTTP protocol",
 			servicePort: corev1.ServicePort{Port: 82, NodePort: 8082},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBSvcProtocol:           string(hcloud.LoadBalancerServiceProtocolHTTP),
-				annotation.LBSvcHTTPCookieName:     "my-cookie",
-				annotation.LBSvcHTTPCookieLifetime: "1h",
-				annotation.LBSvcHTTPCertificates:   "1,3",
-				annotation.LBSvcRedirectHTTP:       "true",
-				annotation.LBSvcHTTPStickySessions: "true",
-				annotation.LBSvcHTTPTimeoutIdle:    "30s",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBSvcProtocol):           string(hcloud.LoadBalancerServiceProtocolHTTP),
+				string(annotation.LBSvcHTTPCookieName):     "my-cookie",
+				string(annotation.LBSvcHTTPCookieLifetime): "1h",
+				string(annotation.LBSvcHTTPCertificates):   "1,3",
+				string(annotation.LBSvcRedirectHTTP):       "true",
+				string(annotation.LBSvcHTTPStickySessions): "true",
+				string(annotation.LBSvcHTTPTimeoutIdle):    "30s",
 			},
 			expectedAddOpts: hcloud.LoadBalancerAddServiceOpts{
 				ListenPort:      new(82),
@@ -159,9 +160,9 @@ func TestHCLBServiceOptsBuilder(t *testing.T) {
 		{
 			name:        "add certificates by name",
 			servicePort: corev1.ServicePort{Port: 83, NodePort: 8083},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBSvcProtocol:         string(hcloud.LoadBalancerServiceProtocolHTTPS),
-				annotation.LBSvcHTTPCertificates: "cert-1,cert-2",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBSvcProtocol):         string(hcloud.LoadBalancerServiceProtocolHTTPS),
+				string(annotation.LBSvcHTTPCertificates): "cert-1,cert-2",
 			},
 			mock: func(_ *testing.T, tt *testCase) {
 				tt.certClient.
@@ -231,10 +232,10 @@ func TestHCLBServiceOptsBuilder(t *testing.T) {
 			name:        "add managed certificate by service uid label",
 			servicePort: corev1.ServicePort{Port: 83, NodePort: 8083},
 			serviceUID:  "some-service-uid",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBSvcProtocol:                      string(hcloud.LoadBalancerServiceProtocolHTTPS),
-				annotation.LBSvcHTTPCertificateType:           "managed",
-				annotation.LBSvcHTTPManagedCertificateDomains: "*.example.com,example.com",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBSvcProtocol):                      string(hcloud.LoadBalancerServiceProtocolHTTPS),
+				string(annotation.LBSvcHTTPCertificateType):           "managed",
+				string(annotation.LBSvcHTTPManagedCertificateDomains): "*.example.com,example.com",
 			},
 			mock: func(_ *testing.T, tt *testCase) {
 				tt.certClient.
@@ -272,9 +273,9 @@ func TestHCLBServiceOptsBuilder(t *testing.T) {
 		{
 			name:        "add health check with default protocol",
 			servicePort: corev1.ServicePort{Port: 83, NodePort: 8083},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBSvcProtocol:        string(hcloud.LoadBalancerServiceProtocolTCP),
-				annotation.LBSvcHealthCheckPort: "8084",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBSvcProtocol):        string(hcloud.LoadBalancerServiceProtocolTCP),
+				string(annotation.LBSvcHealthCheckPort): "8084",
 			},
 			expectedAddOpts: hcloud.LoadBalancerAddServiceOpts{
 				ListenPort:      new(83),
@@ -297,12 +298,12 @@ func TestHCLBServiceOptsBuilder(t *testing.T) {
 		{
 			name:        "add TCP health check",
 			servicePort: corev1.ServicePort{Port: 83, NodePort: 8083},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBSvcHealthCheckProtocol: string(hcloud.LoadBalancerServiceProtocolTCP),
-				annotation.LBSvcHealthCheckPort:     "8084",
-				annotation.LBSvcHealthCheckInterval: "1h",
-				annotation.LBSvcHealthCheckTimeout:  "30s",
-				annotation.LBSvcHealthCheckRetries:  "5",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBSvcHealthCheckProtocol): string(hcloud.LoadBalancerServiceProtocolTCP),
+				string(annotation.LBSvcHealthCheckPort):     "8084",
+				string(annotation.LBSvcHealthCheckInterval): "1h",
+				string(annotation.LBSvcHealthCheckTimeout):  "30s",
+				string(annotation.LBSvcHealthCheckRetries):  "5",
 			},
 			expectedAddOpts: hcloud.LoadBalancerAddServiceOpts{
 				ListenPort:      new(83),
@@ -331,16 +332,16 @@ func TestHCLBServiceOptsBuilder(t *testing.T) {
 		{
 			name:        "add HTTP health check",
 			servicePort: corev1.ServicePort{Port: 84, NodePort: 8084},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBSvcHealthCheckProtocol:                string(hcloud.LoadBalancerServiceProtocolHTTP),
-				annotation.LBSvcHealthCheckPort:                    "8085",
-				annotation.LBSvcHealthCheckInterval:                "1h",
-				annotation.LBSvcHealthCheckTimeout:                 "30s",
-				annotation.LBSvcHealthCheckRetries:                 "5",
-				annotation.LBSvcHealthCheckHTTPDomain:              "example.com",
-				annotation.LBSvcHealthCheckHTTPPath:                "/internal/health",
-				annotation.LBSvcHealthCheckHTTPValidateCertificate: "true",
-				annotation.LBSvcHealthCheckHTTPStatusCodes:         "200,202",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBSvcHealthCheckProtocol):                string(hcloud.LoadBalancerServiceProtocolHTTP),
+				string(annotation.LBSvcHealthCheckPort):                    "8085",
+				string(annotation.LBSvcHealthCheckInterval):                "1h",
+				string(annotation.LBSvcHealthCheckTimeout):                 "30s",
+				string(annotation.LBSvcHealthCheckRetries):                 "5",
+				string(annotation.LBSvcHealthCheckHTTPDomain):              "example.com",
+				string(annotation.LBSvcHealthCheckHTTPPath):                "/internal/health",
+				string(annotation.LBSvcHealthCheckHTTPValidateCertificate): "true",
+				string(annotation.LBSvcHealthCheckHTTPStatusCodes):         "200,202",
 			},
 			expectedAddOpts: hcloud.LoadBalancerAddServiceOpts{
 				ListenPort:      new(84),
@@ -381,15 +382,15 @@ func TestHCLBServiceOptsBuilder(t *testing.T) {
 		{
 			name:        "health check port defaults to node port/destination Port if not specified",
 			servicePort: corev1.ServicePort{Port: 84, NodePort: 8084},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBSvcHealthCheckProtocol:                string(hcloud.LoadBalancerServiceProtocolHTTP),
-				annotation.LBSvcHealthCheckInterval:                "1h",
-				annotation.LBSvcHealthCheckTimeout:                 "30s",
-				annotation.LBSvcHealthCheckRetries:                 "5",
-				annotation.LBSvcHealthCheckHTTPDomain:              "example.com",
-				annotation.LBSvcHealthCheckHTTPPath:                "/internal/health",
-				annotation.LBSvcHealthCheckHTTPValidateCertificate: "true",
-				annotation.LBSvcHealthCheckHTTPStatusCodes:         "200,202",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBSvcHealthCheckProtocol):                string(hcloud.LoadBalancerServiceProtocolHTTP),
+				string(annotation.LBSvcHealthCheckInterval):                "1h",
+				string(annotation.LBSvcHealthCheckTimeout):                 "30s",
+				string(annotation.LBSvcHealthCheckRetries):                 "5",
+				string(annotation.LBSvcHealthCheckHTTPDomain):              "example.com",
+				string(annotation.LBSvcHealthCheckHTTPPath):                "/internal/health",
+				string(annotation.LBSvcHealthCheckHTTPValidateCertificate): "true",
+				string(annotation.LBSvcHealthCheckHTTPStatusCodes):         "200,202",
 			},
 			expectedAddOpts: hcloud.LoadBalancerAddServiceOpts{
 				ListenPort:      new(84),
@@ -451,9 +452,7 @@ func TestHCLBServiceOptsBuilder(t *testing.T) {
 				CertOps: &CertificateOps{ActionClient: tt.actionClient, CertClient: tt.certClient},
 				cfg:     tt.cfg,
 			}
-			for k, v := range tt.serviceAnnotations {
-				builder.Service.Annotations[string(k)] = v
-			}
+			maps.Copy(builder.Service.Annotations, tt.serviceAnnotations)
 			addOpts, err := builder.buildAddServiceOpts()
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedAddOpts, addOpts)

--- a/internal/hcops/load_balancer_test.go
+++ b/internal/hcops/load_balancer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math/rand"
 	"net"
 	"testing"
@@ -243,7 +244,7 @@ func TestLoadBalancerOps_Create(t *testing.T) {
 	type testCase struct {
 		name               string
 		cfg                config.HCCMConfiguration
-		serviceAnnotations map[annotation.Name]string
+		serviceAnnotations map[string]string
 		createOpts         hcloud.LoadBalancerCreateOpts
 		mock               func(t *testing.T, tt *testCase, fx *hcops.LoadBalancerOpsFixture)
 		lb                 *hcloud.LoadBalancer
@@ -257,8 +258,8 @@ func TestLoadBalancerOps_Create(t *testing.T) {
 					Location: "hel1",
 				},
 			},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBLocation: "fsn1",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBLocation): "fsn1",
 			},
 			createOpts: hcloud.LoadBalancerCreateOpts{
 				Name:             "some-lb",
@@ -279,8 +280,8 @@ func TestLoadBalancerOps_Create(t *testing.T) {
 					NetworkZone: "eu-central",
 				},
 			},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBNetworkZone: "eu-central",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBNetworkZone): "eu-central",
 			},
 			createOpts: hcloud.LoadBalancerCreateOpts{
 				Name:             "another-lb",
@@ -335,9 +336,9 @@ func TestLoadBalancerOps_Create(t *testing.T) {
 					Location: "hel1",
 				},
 			},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBLocation:    "",
-				annotation.LBNetworkZone: "eu-central",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBLocation):    "",
+				string(annotation.LBNetworkZone): "eu-central",
 			},
 			createOpts: hcloud.LoadBalancerCreateOpts{
 				Name:             "another-lb",
@@ -356,9 +357,9 @@ func TestLoadBalancerOps_Create(t *testing.T) {
 					NetworkZone: "eu-central",
 				},
 			},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBLocation:    "fsn1",
-				annotation.LBNetworkZone: "",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBLocation):    "fsn1",
+				string(annotation.LBNetworkZone): "",
 			},
 			createOpts: hcloud.LoadBalancerCreateOpts{
 				Name:             "another-lb",
@@ -374,15 +375,15 @@ func TestLoadBalancerOps_Create(t *testing.T) {
 		},
 		{
 			name:               "fails if location and network zone missing",
-			serviceAnnotations: map[annotation.Name]string{},
+			serviceAnnotations: map[string]string{},
 			err: fmt.Errorf("hcops/LoadBalancerOps.Create: neither %s nor %s set",
 				annotation.LBLocation, annotation.LBNetworkZone),
 		},
 		{
 			name: "gives preference to location name",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBLocation:    "nbg1",
-				annotation.LBNetworkZone: "eu-central",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBLocation):    "nbg1",
+				string(annotation.LBNetworkZone): "eu-central",
 			},
 			createOpts: hcloud.LoadBalancerCreateOpts{
 				Name:             "another-lb",
@@ -396,9 +397,9 @@ func TestLoadBalancerOps_Create(t *testing.T) {
 		},
 		{
 			name: "set Load Balancer type name",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBType:     "lb21",
-				annotation.LBLocation: "nbg1",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBType):     "lb21",
+				string(annotation.LBLocation): "nbg1",
 			},
 			createOpts: hcloud.LoadBalancerCreateOpts{
 				Name:             "another-lb",
@@ -412,9 +413,9 @@ func TestLoadBalancerOps_Create(t *testing.T) {
 		},
 		{
 			name: "set Load Balancer algorithm type",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBLocation:      "nbg1",
-				annotation.LBAlgorithmType: "least_connections",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBLocation):      "nbg1",
+				string(annotation.LBAlgorithmType): "least_connections",
 			},
 			createOpts: hcloud.LoadBalancerCreateOpts{
 				Name:             "another-lb",
@@ -466,17 +467,17 @@ func TestLoadBalancerOps_Create(t *testing.T) {
 		},
 		{
 			name: "fail on invalid Load Balancer algorithm type",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBLocation:      "nbg1",
-				annotation.LBAlgorithmType: "invalidType",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBLocation):      "nbg1",
+				string(annotation.LBAlgorithmType): "invalidType",
 			},
 			err: fmt.Errorf("hcops/LoadBalancerOps.Create: annotation/Name.LBAlgorithmTypeFromService: annotation/validateAlgorithmType: invalid: invalidtype"),
 		},
 		{
 			name: "disable public interface",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBLocation:             "nbg1",
-				annotation.LBDisablePublicNetwork: "true",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBLocation):             "nbg1",
+				string(annotation.LBDisablePublicNetwork): "true",
 			},
 			createOpts: hcloud.LoadBalancerCreateOpts{
 				Name:             "lb-with-priv",
@@ -520,9 +521,7 @@ func TestLoadBalancerOps_Create(t *testing.T) {
 					Annotations: map[string]string{},
 				},
 			}
-			for k, v := range tt.serviceAnnotations {
-				service.Annotations[string(k)] = v
-			}
+			maps.Copy(service.Annotations, tt.serviceAnnotations)
 
 			lb, err := fx.LBOps.Create(fx.Ctx, tt.createOpts.Name, service)
 			if tt.err != nil {
@@ -578,7 +577,7 @@ type LBReconcilementTestCase struct {
 	name               string
 	cfg                config.HCCMConfiguration
 	serviceUID         string
-	serviceAnnotations map[annotation.Name]string
+	serviceAnnotations map[string]string
 	servicePorts       []corev1.ServicePort
 	k8sNodes           []*corev1.Node
 	initialLB          *hcloud.LoadBalancer
@@ -606,9 +605,7 @@ func (tt *LBReconcilementTestCase) run(t *testing.T) {
 			},
 		}
 	}
-	for k, v := range tt.serviceAnnotations {
-		tt.service.Annotations[string(k)] = v
-	}
+	maps.Copy(tt.service.Annotations, tt.serviceAnnotations)
 	if tt.mock != nil {
 		tt.mock(t, tt)
 	}
@@ -620,8 +617,8 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 	tests := []LBReconcilementTestCase{
 		{
 			name: "update algorithm",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBAlgorithmType: string(hcloud.LoadBalancerAlgorithmTypeLeastConnections),
+			serviceAnnotations: map[string]string{
+				string(annotation.LBAlgorithmType): string(hcloud.LoadBalancerAlgorithmTypeLeastConnections),
 			},
 			initialLB: &hcloud.LoadBalancer{
 				ID: 1,
@@ -649,8 +646,8 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 		},
 		{
 			name: "update to invalid algorithm",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBAlgorithmType: "invalidType",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBAlgorithmType): "invalidType",
 			},
 			initialLB: &hcloud.LoadBalancer{
 				ID: 2,
@@ -670,8 +667,8 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 		},
 		{
 			name: "don't update unchanged algorithm",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBAlgorithmType: string(hcloud.LoadBalancerAlgorithmTypeRoundRobin),
+			serviceAnnotations: map[string]string{
+				string(annotation.LBAlgorithmType): string(hcloud.LoadBalancerAlgorithmTypeRoundRobin),
 			},
 			initialLB: &hcloud.LoadBalancer{
 				ID: 3,
@@ -690,8 +687,8 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 		},
 		{
 			name: "update type",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBType: "lb21",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBType): "lb21",
 			},
 			initialLB: &hcloud.LoadBalancer{
 				ID: 1,
@@ -754,8 +751,8 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 		},
 		{
 			name: "don't update unchanged type",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBType: "lb21",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBType): "lb21",
 			},
 			initialLB: &hcloud.LoadBalancer{
 				ID: 1,
@@ -774,8 +771,8 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 		},
 		{
 			name: "don't update correct IPv4 RNDS",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBPublicIPv4RDNS: "lb.example.com",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBPublicIPv4RDNS): "lb.example.com",
 			},
 			initialLB: &hcloud.LoadBalancer{
 				ID: 6,
@@ -794,8 +791,8 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 		},
 		{
 			name: "update incorrect IPv4 RNDS",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBPublicIPv4RDNS: "new-name-lb.example.com",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBPublicIPv4RDNS): "new-name-lb.example.com",
 			},
 			initialLB: &hcloud.LoadBalancer{
 				ID: 6,
@@ -821,8 +818,8 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 		},
 		{
 			name: "don't update correct IPv6 RNDS",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBPublicIPv6RDNS: "lb.example.com",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBPublicIPv6RDNS): "lb.example.com",
 			},
 			initialLB: &hcloud.LoadBalancer{
 				ID: 6,
@@ -841,8 +838,8 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 		},
 		{
 			name: "update incorrect IPv6 RNDS",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBPublicIPv6RDNS: "new-name-lb.example.com",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBPublicIPv6RDNS): "new-name-lb.example.com",
 			},
 			initialLB: &hcloud.LoadBalancer{
 				ID: 6,
@@ -907,8 +904,8 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 					Enabled: true,
 				},
 			},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBPrivateIPv4: "10.10.10.2",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBPrivateIPv4): "10.10.10.2",
 			},
 			mock: func(_ *testing.T, tt *LBReconcilementTestCase) {
 				nw := &hcloud.Network{ID: 14, Name: "some-network"}
@@ -993,8 +990,8 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 					Enabled: true,
 				},
 			},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBPrivateIPv4: "10.10.10.2",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBPrivateIPv4): "10.10.10.2",
 			},
 			mock: func(_ *testing.T, tt *LBReconcilementTestCase) {
 				nw := &hcloud.Network{ID: 15, Name: "some-network"}
@@ -1105,8 +1102,8 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 		},
 		{
 			name: "disable enabled public network",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBDisablePublicNetwork: "true",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBDisablePublicNetwork): "true",
 			},
 			initialLB: &hcloud.LoadBalancer{
 				ID: 6,
@@ -1155,8 +1152,8 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 		},
 		{
 			name: "keep disabled public interface",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBDisablePublicNetwork: "true",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBDisablePublicNetwork): "true",
 			},
 			initialLB: &hcloud.LoadBalancer{
 				ID: 7,
@@ -1172,8 +1169,8 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 		},
 		{
 			name: "enable disabled public interface",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBDisablePublicNetwork: "false",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBDisablePublicNetwork): "false",
 			},
 			initialLB: &hcloud.LoadBalancer{
 				ID: 8,
@@ -1196,8 +1193,8 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 		},
 		{
 			name: "keep enabled public interface",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBDisablePublicNetwork: "false",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBDisablePublicNetwork): "false",
 			},
 			initialLB: &hcloud.LoadBalancer{
 				ID: 9,
@@ -1294,8 +1291,8 @@ func TestLoadBalancerOps_ReconcileHCLB(t *testing.T) {
 		{
 			name:       "rename load balancer",
 			serviceUID: "11",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBName: "new-name",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBName): "new-name",
 			},
 			initialLB: &hcloud.LoadBalancer{
 				ID:   11,
@@ -1557,8 +1554,8 @@ func TestLoadBalancerOps_ReconcileHCLBTargets(t *testing.T) {
 				{Spec: corev1.NodeSpec{ProviderID: "hcloud://1"}},
 				{Spec: corev1.NodeSpec{ProviderID: "hcloud://2"}},
 			},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBUsePrivateIP: "true",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBUsePrivateIP): "true",
 			},
 			initialLB: &hcloud.LoadBalancer{
 				ID: 3,
@@ -1597,8 +1594,8 @@ func TestLoadBalancerOps_ReconcileHCLBTargets(t *testing.T) {
 			k8sNodes: []*corev1.Node{
 				{Spec: corev1.NodeSpec{ProviderID: "hcloud://1"}},
 			},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBUsePrivateIP: "false",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBUsePrivateIP): "false",
 			},
 			initialLB: &hcloud.LoadBalancer{
 				ID: 4,
@@ -1843,8 +1840,8 @@ func TestLoadBalancerOps_ReconcileHCLBServices(t *testing.T) {
 					MaxTargets: 25,
 				},
 			},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBSvcHTTPCertificates: "1",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBSvcHTTPCertificates): "1",
 			},
 			mock: func(_ *testing.T, tt *LBReconcilementTestCase) {
 				opts := hcloud.LoadBalancerAddServiceOpts{
@@ -1881,8 +1878,8 @@ func TestLoadBalancerOps_ReconcileHCLBServices(t *testing.T) {
 					MaxTargets: 25,
 				},
 			},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBSvcHTTPCertificates: "some-cert",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBSvcHTTPCertificates): "some-cert",
 			},
 			mock: func(_ *testing.T, tt *LBReconcilementTestCase) {
 				cert := &hcloud.Certificate{ID: 1}
@@ -1915,9 +1912,9 @@ func TestLoadBalancerOps_ReconcileHCLBServices(t *testing.T) {
 			name:         "create managed certificate",
 			servicePorts: []corev1.ServicePort{{Port: 443, NodePort: 8443}},
 			initialLB:    &hcloud.LoadBalancer{ID: 11},
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBSvcHTTPCertificateType:           string(hcloud.CertificateTypeManaged),
-				annotation.LBSvcHTTPManagedCertificateDomains: "example.com,*.example.com",
+			serviceAnnotations: map[string]string{
+				string(annotation.LBSvcHTTPCertificateType):           string(hcloud.CertificateTypeManaged),
+				string(annotation.LBSvcHTTPManagedCertificateDomains): "example.com,*.example.com",
 			},
 			serviceUID: "some service uid",
 			mock: func(_ *testing.T, tt *LBReconcilementTestCase) {
@@ -1966,8 +1963,8 @@ func TestLoadBalancerOps_ReconcileHCLBServices(t *testing.T) {
 		},
 		{
 			name: "replace hc Load Balancer services",
-			serviceAnnotations: map[annotation.Name]string{
-				annotation.LBSvcProtocol: string(hcloud.LoadBalancerServiceProtocolHTTP),
+			serviceAnnotations: map[string]string{
+				string(annotation.LBSvcProtocol): string(hcloud.LoadBalancerServiceProtocolHTTP),
 			},
 			servicePorts: []corev1.ServicePort{
 				{Port: 81, NodePort: 8081},

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -41,14 +41,14 @@ const (
 // lbCreateTimeoutFor returns the timeout to use when waiting for the given
 // Load Balancer service to become ready.
 func lbCreateTimeoutFor(svc *corev1.Service) time.Duration {
-	certAnnotations := []annotation.Name{
-		annotation.LBSvcHTTPCertificates,
-		annotation.LBSvcHTTPCertificateType,
-		annotation.LBSvcHTTPManagedCertificateName,
-		annotation.LBSvcHTTPManagedCertificateDomains,
+	certAnnotations := []string{
+		string(annotation.LBSvcHTTPCertificates),
+		string(annotation.LBSvcHTTPCertificateType),
+		string(annotation.LBSvcHTTPManagedCertificateName),
+		string(annotation.LBSvcHTTPManagedCertificateDomains),
 	}
 	for _, a := range certAnnotations {
-		if _, ok := svc.Annotations[string(a)]; ok {
+		if _, ok := svc.Annotations[a]; ok {
 			return lbCreateTimeoutCert
 		}
 	}


### PR DESCRIPTION
Preparation for upcoming refactoring.