### PR TITLE
fix(instances): skip IPv6 ExternalIP for Robot servers without a subnet

### DIFF
--- a/hcloud/instances.go
+++ b/hcloud/instances.go
@@ -41,6 +41,7 @@ import (
 const (
 	ProvidedBy              = "instance.hetzner.cloud/provided-by"
 	MisconfiguredInternalIP = "MisconfiguredInternalIP"
+	InvalidIPv6Net          = "InvalidIPv6Net"
 	instancesV2Subsystem    = "instances_v2"
 )
 
@@ -281,10 +282,23 @@ func robotNodeAddresses(
 	ipv4 := cfg.Instance.AddressFamily == config.AddressFamilyIPv4 || dualStack
 	ipv6 := cfg.Instance.AddressFamily == config.AddressFamilyIPv6 || dualStack
 
-	if ipv6 {
+	// Robot servers do not necessarily have an IPv6 subnet assigned, in which case the field is empty.
+	if ipv6 && server.ServerIPv6Net != "" {
 		// For a given IPv6 network of 2a01:f48:111:4221::, the instance address is 2a01:f48:111:4221::1
 		hostAddress := server.ServerIPv6Net + "1"
-		addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: hostAddress})
+
+		if net.ParseIP(hostAddress) == nil {
+			utils.WarnEventLogf(
+				recorder,
+				node,
+				InvalidIPv6Net,
+				"Robot server %q reports the IPv6 subnet %q, which does not yield a valid address. As a result, no IPv6 ExternalIP is added",
+				server.Name,
+				server.ServerIPv6Net,
+			)
+		} else {
+			addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: hostAddress})
+		}
 	}
 
 	if ipv4 {

--- a/hcloud/instances.go
+++ b/hcloud/instances.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
+	"slices"
 
 	hrobot "github.com/syself/hrobot-go"
 	hrobotmodels "github.com/syself/hrobot-go/models"
@@ -275,19 +277,18 @@ func robotNodeAddresses(
 	cfg config.HCCMConfiguration,
 	recorder record.EventRecorder,
 ) []corev1.NodeAddress {
-	var addresses []corev1.NodeAddress
-	addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeHostName, Address: server.Name})
+	family := cfg.Instance.AddressFamily
+	dualStack := family == config.AddressFamilyDualStack
+	ipv4 := family == config.AddressFamilyIPv4 || dualStack
+	ipv6 := family == config.AddressFamilyIPv6 || dualStack
 
-	dualStack := cfg.Instance.AddressFamily == config.AddressFamilyDualStack
-	ipv4 := cfg.Instance.AddressFamily == config.AddressFamilyIPv4 || dualStack
-	ipv6 := cfg.Instance.AddressFamily == config.AddressFamilyIPv6 || dualStack
+	addresses := []corev1.NodeAddress{{Type: corev1.NodeHostName, Address: server.Name}}
 
 	// Robot servers do not necessarily have an IPv6 subnet assigned, in which case the field is empty.
 	if ipv6 && server.ServerIPv6Net != "" {
-		// For a given IPv6 network of 2a01:f48:111:4221::, the instance address is 2a01:f48:111:4221::1
-		hostAddress := server.ServerIPv6Net + "1"
-
-		if net.ParseIP(hostAddress) == nil {
+		if hostAddress := robotIPv6HostAddress(server.ServerIPv6Net); hostAddress != "" {
+			addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: hostAddress})
+		} else {
 			utils.WarnEventLogf(
 				recorder,
 				node,
@@ -296,8 +297,6 @@ func robotNodeAddresses(
 				server.Name,
 				server.ServerIPv6Net,
 			)
-		} else {
-			addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: hostAddress})
 		}
 	}
 
@@ -306,47 +305,67 @@ func robotNodeAddresses(
 	}
 
 	if cfg.Robot.ForwardInternalIPs {
-	OUTER:
-		for _, currentAddress := range node.Status.Addresses {
-			if currentAddress.Type != corev1.NodeInternalIP {
-				continue
-			}
+		addresses = appendForwardedInternalIPs(addresses, node, family, recorder)
+	}
 
-			ip := net.ParseIP(currentAddress.Address)
-			isIPv4 := ip.To4() != nil
+	return addresses
+}
 
-			var warnMsg string
-			if isIPv4 && ipv6 && !dualStack {
-				warnMsg = fmt.Sprintf(
-					"Configured InternalIP is IPv4 even though IPv6 only is configured. As a result, %s is not added as an InternalIP",
-					currentAddress.Address,
-				)
-			} else if !isIPv4 && ipv4 && !dualStack {
-				warnMsg = fmt.Sprintf(
-					"Configured InternalIP is IPv6 even though IPv4 only is configured. As a result, %s is not added as an InternalIP",
-					currentAddress.Address,
-				)
-			}
+func robotIPv6HostAddress(subnet string) string {
+	addr, err := netip.ParseAddr(subnet)
+	if err != nil || !addr.Is6() || addr.Is4In6() {
+		return ""
+	}
 
-			if warnMsg != "" {
-				utils.WarnEventLogf(recorder, node, MisconfiguredInternalIP, "%s", warnMsg)
-				continue
-			}
+	hostAddress := addr.As16()
+	hostAddress[len(hostAddress)-1] |= 0x01
 
-			for _, address := range addresses {
-				if currentAddress.Address == address.Address {
-					utils.WarnEventLogf(
-						recorder,
-						node,
-						MisconfiguredInternalIP,
-						"Configured InternalIP already exists as an ExternalIP. As a result, %s is not added as an InternalIP",
-						currentAddress.Address,
-					)
-					continue OUTER
-				}
-			}
+	return netip.AddrFrom16(hostAddress).String()
+}
 
-			addresses = append(addresses, currentAddress)
+func appendForwardedInternalIPs(
+	addresses []corev1.NodeAddress,
+	node *corev1.Node,
+	family config.AddressFamily,
+	recorder record.EventRecorder,
+) []corev1.NodeAddress {
+	for _, internalIP := range node.Status.Addresses {
+		if internalIP.Type != corev1.NodeInternalIP {
+			continue
+		}
+
+		isIPv4 := net.ParseIP(internalIP.Address).To4() != nil
+		isKnown := slices.ContainsFunc(addresses, func(address corev1.NodeAddress) bool {
+			return address.Address == internalIP.Address
+		})
+
+		switch {
+		case isIPv4 && family == config.AddressFamilyIPv6:
+			utils.WarnEventLogf(
+				recorder,
+				node,
+				MisconfiguredInternalIP,
+				"Configured InternalIP is IPv4 even though IPv6 only is configured. As a result, %s is not added as an InternalIP",
+				internalIP.Address,
+			)
+		case !isIPv4 && family == config.AddressFamilyIPv4:
+			utils.WarnEventLogf(
+				recorder,
+				node,
+				MisconfiguredInternalIP,
+				"Configured InternalIP is IPv6 even though IPv4 only is configured. As a result, %s is not added as an InternalIP",
+				internalIP.Address,
+			)
+		case isKnown:
+			utils.WarnEventLogf(
+				recorder,
+				node,
+				MisconfiguredInternalIP,
+				"Configured InternalIP already exists as an ExternalIP. As a result, %s is not added as an InternalIP",
+				internalIP.Address,
+			)
+		default:
+			addresses = append(addresses, internalIP)
 		}
 	}
 

--- a/hcloud/instances_test.go
+++ b/hcloud/instances_test.go
@@ -712,6 +712,41 @@ func TestNodeAddressesRobotServer(t *testing.T) {
 				{Type: corev1.NodeExternalIP, Address: "203.0.113.7"},
 			},
 		},
+		{
+			name:          "public ipv6 without IPv6 subnet",
+			addressFamily: config.AddressFamilyIPv6,
+			server: &hrobotmodels.Server{
+				Name:     "foobar",
+				ServerIP: "203.0.113.7",
+			},
+			expected: []corev1.NodeAddress{
+				{Type: corev1.NodeHostName, Address: "foobar"},
+			},
+		},
+		{
+			name:          "public dual stack without IPv6 subnet",
+			addressFamily: config.AddressFamilyDualStack,
+			server: &hrobotmodels.Server{
+				Name:     "foobar",
+				ServerIP: "203.0.113.7",
+			},
+			expected: []corev1.NodeAddress{
+				{Type: corev1.NodeHostName, Address: "foobar"},
+				{Type: corev1.NodeExternalIP, Address: "203.0.113.7"},
+			},
+		},
+		{
+			name:          "public ipv6 with malformed IPv6 subnet",
+			addressFamily: config.AddressFamilyIPv6,
+			server: &hrobotmodels.Server{
+				Name:          "foobar",
+				ServerIP:      "203.0.113.7",
+				ServerIPv6Net: "2001:db8:1234::/64",
+			},
+			expected: []corev1.NodeAddress{
+				{Type: corev1.NodeHostName, Address: "foobar"},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Problem

`robotNodeAddresses` builds the IPv6 ExternalIP of a Robot server by appending `1` to `server.ServerIPv6Net` (`hcloud/instances.go`):

```go
if ipv6 {
    // For a given IPv6 network of 2a01:f48:111:4221::, the instance address is 2a01:f48:111:4221::1
    hostAddress := server.ServerIPv6Net + "1"
    addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: hostAddress})
}
```

Robot servers do not necessarily have an IPv6 subnet assigned. In that case the Robot API reports an empty `server_ipv6_net`, the concatenation yields the literal string `1`, and that ends up on the Node object:

```yaml
status:
  addresses:
    - address: "1"
      type: ExternalIP
```

The same applies to any value that does not yield a valid address after the concatenation — a subnet reported with a prefix length, for example, produces `2001:db8:1234::/641`.

This affects `HCLOUD_INSTANCES_ADDRESS_FAMILY=ipv6` and `dualstack`. The default `ipv4` never enters this branch.

The equivalent Cloud code path is already guarded (`ipv4 && !server.PublicNet.IPv4.IsUnspecified()` / `ipv6 && !server.PublicNet.IPv6.IsUnspecified()`), because it works with real `net.IP` values instead of string concatenation. The Robot path has no such check.

## Impact

The invalid entry is written to `status.addresses` on every reconciliation and breaks consumers that parse node ExternalIPs. Found on a hybrid cluster whose Robot servers have no IPv6 subnet recorded in Robot.

## Fix

- Skip the IPv6 ExternalIP when `ServerIPv6Net` is empty.
- Validate the concatenated address with `net.ParseIP` before adding it, and emit an `InvalidIPv6Net` warning event when the reported subnet does not yield a valid address.

## Tests

Three cases added to `TestNodeAddressesRobotServer`, covering ipv6-only and dual-stack without a subnet, and a malformed subnet. Without the fix they fail as:

```
--- FAIL: TestNodeAddressesRobotServer/public_ipv6_without_IPv6_subnet
    expected addresses [{Type:Hostname Address:foobar}]
         but got       [{Type:Hostname Address:foobar} {Type:ExternalIP Address:1}]

--- FAIL: TestNodeAddressesRobotServer/public_dual_stack_without_IPv6_subnet
    expected addresses [{Type:Hostname Address:foobar} {Type:ExternalIP Address:203.0.113.7}]
         but got       [{Type:Hostname Address:foobar} {Type:ExternalIP Address:1} {Type:ExternalIP Address:203.0.113.7}]

--- FAIL: TestNodeAddressesRobotServer/public_ipv6_with_malformed_IPv6_subnet
    expected addresses [{Type:Hostname Address:foobar}]
         but got       [{Type:Hostname Address:foobar} {Type:ExternalIP Address:2001:db8:1234::/641}]
```