### PR TITLE
chore: enable podmonitor on snapshots

### DIFF
--- a/chart/.snapshots/full.daemonset.yaml
+++ b/chart/.snapshots/full.daemonset.yaml
@@ -193,3 +193,21 @@ spec:
         - name: token-volume
           secret:
             secretName: hcloud-token
+---
+# Source: hcloud-cloud-controller-manager/templates/podmonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: hcloud-cloud-controller-manager
+  namespace: kube-system
+  labels:
+    environment: staging
+  annotations:
+    release: "kube-prometheus-stack"
+spec:
+  podMetricsEndpoints:
+  - port: metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: 'hcloud-hccm'
+      app.kubernetes.io/name: 'hcloud-cloud-controller-manager'

--- a/chart/Makefile
+++ b/chart/Makefile
@@ -6,15 +6,26 @@ all: lint snapshots deploy-manifests
 
 # ----- Snapshots -----
 
+# Templates gated behind .Capabilities.APIVersions are not rendered unless the
+# API is declared, as `helm template` runs without a cluster.
+API_VERSIONS = --api-versions monitoring.coreos.com/v1/PodMonitor
+
 .PHONY: snapshots-clean
 snapshots-clean:
 	rm -f .snapshots/*
 
 .snapshots/default.yaml:
-	helm template hcloud-hccm . $(RELEASE_NAMESPACE) > "$@"
+	helm template hcloud-hccm . \
+		$(RELEASE_NAMESPACE) \
+		$(API_VERSIONS) \
+		> "$@"
 
 .snapshots/%.yaml: %-values.yaml
-	helm template hcloud-hccm . $(RELEASE_NAMESPACE) -f "$<" > "$@"
+	helm template hcloud-hccm . \
+		$(RELEASE_NAMESPACE) \
+		$(API_VERSIONS) \
+		-f "$<" \
+		> "$@"
 
 .PHONY: snapshots
 snapshots: snapshots-clean .snapshots/*

--- a/chart/full.daemonset-values.yaml
+++ b/chart/full.daemonset-values.yaml
@@ -6,6 +6,7 @@ serviceAccount:
 
 monitoring:
   podMonitor:
+    enabled: true
     labels:
       environment: staging
     annotations:

--- a/chart/templates/podmonitor.yaml
+++ b/chart/templates/podmonitor.yaml
@@ -5,14 +5,16 @@ kind: PodMonitor
 metadata:
   name: {{ include "hcloud-cloud-controller-manager.name" . }}
   namespace: {{ .Release.Namespace }}
+  {{- with $.Values.monitoring.podMonitor.labels }}
   labels:
-    {{- with $.Values.monitoring.podMonitor.labels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $.Values.monitoring.podMonitor.annotations }}
   annotations:
-    {{- range $key, $value := .Values.monitoring.podMonitor.annotations }}
+    {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
+  {{- end }}
 spec:
   {{- tpl (toYaml $.Values.monitoring.podMonitor.spec) $ | nindent 2 }}
   selector:


### PR DESCRIPTION
In the full.daemonset-values.yaml we set podMonitor specific settings
but the podMonitor was never enabled and is never checked by some of
our pre-commit linters, such as `check-yaml`.

Additionally, adds a guard to labels and annotations.
